### PR TITLE
Subatomic Membership Requests

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -26,10 +26,17 @@ import {SlackIdentity, Team} from "./gluon/shared/sharedIngester";
 import {CreateTeam} from "./gluon/team/CreateTeam";
 import {NewDevOpsEnvironment} from "./gluon/team/DevOpsEnvironment";
 import {DevOpsEnvironmentRequested} from "./gluon/team/DevOpsEnvironmentRequested";
-import {AddMemberToTeam, JoinTeam} from "./gluon/team/JoinTeam";
+import {
+    AddMemberToTeam,
+    CreateMembershipRequestToTeam,
+    JoinTeam,
+} from "./gluon/team/JoinTeam";
+import {MembershipRequestClosed} from "./gluon/team/MembershipRequestClosed";
+import {MembershipRequestCreated} from "./gluon/team/MembershipRequestCreated";
 import {TeamCreated} from "./gluon/team/TeamCreated";
 import {
     DevOpsEnvironmentRequestedEvent,
+    MembershipRequestCreatedEvent,
     TeamCreatedEvent,
 } from "./gluon/team/teamIngester";
 import {
@@ -61,6 +68,8 @@ export const configuration: any = {
         NewProjectEnvironments,
         CreateApplication,
         Whoami,
+        CreateMembershipRequestToTeam,
+        MembershipRequestClosed,
     ],
     events: [
         TeamCreated,
@@ -71,6 +80,7 @@ export const configuration: any = {
         DevOpsEnvironmentRequested,
         ProjectEnvironmentsRequested,
         ApplicationCreated,
+        MembershipRequestCreated,
     ],
     ingesters: [
         SlackIdentity,
@@ -83,6 +93,7 @@ export const configuration: any = {
         DevOpsEnvironmentRequestedEvent,
         ProjectEnvironmentsRequestedEvent,
         ApplicationCreatedEvent,
+        MembershipRequestCreatedEvent,
     ],
     token,
     http: {

--- a/src/gluon/team/JoinTeam.ts
+++ b/src/gluon/team/JoinTeam.ts
@@ -234,14 +234,14 @@ export class CreateMembershipRequestToTeam implements HandleCommand<HandlerResul
     public screenName: string;
 
     @Parameter({
-        description: "slack name of the member to add",
+        description: "Gluon team id to create a membership request to.",
         displayable: false,
 
     })
     public teamId: string;
 
     @Parameter({
-        description: "slack name of the member to add",
+        description: "Slack name of the member to add.",
     })
     public slackName: string;
 

--- a/src/gluon/team/JoinTeam.ts
+++ b/src/gluon/team/JoinTeam.ts
@@ -1,6 +1,15 @@
 import {
-    CommandHandler, failure, HandleCommand, HandlerContext, HandlerResult,
-    logger, MappedParameter, MappedParameters, Parameter, success, Tags,
+    CommandHandler,
+    failure,
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+    logger,
+    MappedParameter,
+    MappedParameters,
+    Parameter,
+    success,
+    Tags,
 } from "@atomist/automation-client";
 import {
     buttonForCommand,
@@ -22,7 +31,7 @@ export class JoinTeam implements HandleCommand<HandlerResult> {
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         return axios.get("http://localhost:8080/teams")
-            .then( teams => {
+            .then(teams => {
                 logger.info(`Got teams data: ${JSON.stringify(teams.data)}`);
 
                 // remove teams that he is already a member of - TODO in future
@@ -37,18 +46,12 @@ export class JoinTeam implements HandleCommand<HandlerResult> {
                                     text: "Select Team", options:
                                         teams.data._embedded.teamResources.map(team => {
                                             return {
-                                                value: _.kebabCase(team.name),
+                                                value: team.teamId,
                                                 text: team.name,
                                             };
                                         }),
                                 },
-                                // TODO this command should notify the team channel of the application
-                                // the options would be to add this member to the team or decline him
-                                // in which case the member should be notified of the outcome
-
-                                // don't make this complicated for now.
-                                // just send a message that he wants to join - that's it
-                                "AddMemberToTeam", "teamChannel",
+                                "CreateMembershipRequestToTeam", "teamId",
                                 {slackName: this.slackName}),
                         ],
                     }],
@@ -58,14 +61,9 @@ export class JoinTeam implements HandleCommand<HandlerResult> {
                     .then(success);
             });
     }
-
-    private docs(): string {
-        return `${url("https://subatomic.bison.absa.co.za/docs/teams#join",
-            "documentation")}`;
-    }
 }
 
-@CommandHandler("Add a member to a team", config.get("subatomic").commandPrefix + " add member")
+@CommandHandler("Add a member to a team")
 @Tags("subatomic", "team", "member")
 export class AddMemberToTeam implements HandleCommand<HandlerResult> {
 
@@ -99,7 +97,7 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
             screenName = _.replace(this.slackName, /(<@)|>/g, "");
         }
 
-        return this.loadScreenNameByUserId(ctx, screenName)
+        return loadScreenNameByUserId(ctx, screenName)
             .then(chatId => {
                 if (!_.isEmpty(chatId)) {
                     logger.info(`Got ChatId: ${chatId}`);
@@ -222,27 +220,78 @@ Adding a team member from Slack requires typing their \`@mention\` name or using
         // that he has the X role assigned to him.
     }
 
-    // see loadChatIdByChatId
-    private loadScreenNameByUserId(ctx: HandlerContext, userId: string): Promise<graphql.ChatId.ChatId> {
-        return ctx.graphClient.executeQueryFromFile<graphql.ChatId.Query, graphql.ChatId.Variables>(
-            "graphql/query/chatIdByUserId",
-            {userId})
-            .then(result => {
-                if (result) {
-                    if (result.ChatId && result.ChatId.length > 0) {
-                        return result.ChatId[0].screenName;
-                    }
-                }
-                return null;
-            })
-            .catch(err => {
-                logger.error("Error occurred running GraphQL query: %s", err);
-                return null;
-            });
-    }
-
     private docs(): string {
         return `${url("https://subatomic.bison.absa.co.za/docs/teams",
             "documentation")}`;
     }
+}
+
+@CommandHandler("Request membership to a team", config.get("subatomic").commandPrefix + " request membership")
+@Tags("subatomic", "team", "member")
+export class CreateMembershipRequestToTeam implements HandleCommand<HandlerResult> {
+
+    @MappedParameter(MappedParameters.SlackUserName)
+    public screenName: string;
+
+    @Parameter({
+        description: "slack name of the member to add",
+        displayable: false,
+
+    })
+    public teamId: string;
+
+    @Parameter({
+        description: "slack name of the member to add",
+    })
+    public slackName: string;
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info(`Request to join team: ${this.teamId}`);
+
+        let screenName = this.slackName;
+        if (this.slackName.startsWith("<@")) {
+            screenName = _.replace(this.slackName, /(<@)|>/g, "");
+        }
+
+        return loadScreenNameByUserId(ctx, screenName)
+            .then(chatId => {
+                if (!_.isEmpty(chatId)) {
+                    logger.info(`Got ChatId: ${chatId}`);
+                    return axios.get(`http://localhost:8080/members?slackScreenName=${chatId}`)
+                        .then(newMember => {
+                            logger.info(`Member: ${JSON.stringify(newMember.data)}`);
+                            return axios.put(`http://localhost:8080/teams/${this.teamId}`,
+                                {
+                                    membershipRequests: [
+                                        {
+                                            requestedBy: {
+                                                memberId: newMember.data._embedded.teamMemberResources[0].memberId,
+                                            },
+                                        }],
+                                }).then(() => {
+                                return success();
+                            });
+
+                        });
+                }
+            }).catch(error => failure(error));
+    }
+}
+
+export function loadScreenNameByUserId(ctx: HandlerContext, userId: string): Promise<graphql.ChatId.ChatId> {
+    return ctx.graphClient.executeQueryFromFile<graphql.ChatId.Query, graphql.ChatId.Variables>(
+        "graphql/query/chatIdByUserId",
+        {userId})
+        .then(result => {
+            if (result) {
+                if (result.ChatId && result.ChatId.length > 0) {
+                    return result.ChatId[0].screenName;
+                }
+            }
+            return null;
+        })
+        .catch(err => {
+            logger.error("Error occurred running GraphQL query: %s", err);
+            return null;
+        });
 }

--- a/src/gluon/team/MembershipRequestClosed.ts
+++ b/src/gluon/team/MembershipRequestClosed.ts
@@ -1,0 +1,96 @@
+import {
+    CommandHandler, failure, HandleCommand, HandlerContext, HandlerResult,
+    logger, MappedParameter, MappedParameters, Parameter, success, Tags,
+} from "@atomist/automation-client";
+import {
+    addressSlackUsers,
+} from "@atomist/automation-client/spi/message/MessageClient";
+import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/handlers/command/slack/AssociateRepo";
+import {SlackMessage} from "@atomist/slack-messages";
+import axios from "axios";
+import * as config from "config";
+
+@CommandHandler("Close a membership request", config.get("subatomic").commandPrefix + " close membership request")
+@Tags("subatomic", "team", "membership")
+export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
+
+    @MappedParameter(MappedParameters.SlackUserName)
+    public approverUserName: string;
+
+    @MappedParameter(MappedParameters.SlackTeam)
+    public slackTeam: string;
+
+    @MappedParameter(MappedParameters.SlackChannel)
+    public slackChannelId: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public teamChannel: string;
+
+    @Parameter({
+        description: "teamId",
+    })
+    public teamId: string;
+
+    @Parameter({
+        description: "Membership request id",
+    })
+    public membershipRequestId: string;
+
+    @Parameter({
+        description: "Slack name of applying user",
+    })
+    public userScreenName: string;
+
+    @Parameter({
+        description: "Slack id of applying user",
+    })
+    public userSlackId: string;
+
+    @Parameter({
+        description: "Status of request approval",
+    })
+    public approvalStatus: string;
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+
+        logger.info(`Attempting approval from user: ${this.approverUserName}`);
+
+        return axios.get(`http://localhost:8080/members?slackScreenName=${this.approverUserName}`)
+            .then(newMember => {
+                logger.info(`Member: ${JSON.stringify(newMember.data)}`);
+                return axios.put(`http://localhost:8080/teams/${this.teamId}`,
+                    {
+                        membershipRequests: [
+                            {
+                                membershipRequestId: this.membershipRequestId,
+                                approvedBy: {
+                                    memberId: newMember.data._embedded.teamMemberResources[0].memberId,
+                                },
+                                requestStatus: this.approvalStatus,
+                            }],
+                    }).then(() => {
+                    if (this.approvalStatus === "APPROVED") {
+                        logger.info(`Added team member! Inviting to channel [${this.slackChannelId}] -> member @${this.userScreenName}`);
+                        return inviteUserToSlackChannel(ctx,
+                            this.slackTeam,
+                            this.slackChannelId,
+                            this.userSlackId)
+                            .then(() => {
+                                const msg: SlackMessage = {
+                                    text: `Welcome to the team *${this.userScreenName}*!`,
+                                };
+
+                                return ctx.messageClient.addressChannels(msg, this.teamChannel);
+                            }, reason => logger.error(reason));
+                    } else {
+                        return ctx.messageClient.send(`Your membership request to team '${this.teamChannel}' has been rejected by @${this.approverUserName}`,
+                            addressSlackUsers(config.get("teamId"), this.userScreenName))
+                            .then(() => {
+                                return ctx.messageClient.addressChannels("Membership request rejected", this.teamChannel);
+                            });
+                    }
+                }).catch(error => failure(error));
+            });
+
+    }
+}

--- a/src/gluon/team/MembershipRequestClosed.ts
+++ b/src/gluon/team/MembershipRequestClosed.ts
@@ -57,7 +57,6 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
     public approvalStatus: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-
         logger.info(`Attempting approval from user: ${this.approverUserName}`);
 
         return axios.get(`http://localhost:8080/members?slackScreenName=${this.approverUserName}`)

--- a/src/gluon/team/MembershipRequestClosed.ts
+++ b/src/gluon/team/MembershipRequestClosed.ts
@@ -27,9 +27,14 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
     public teamChannel: string;
 
     @Parameter({
-        description: "teamId",
+        description: "Gluon team id",
     })
     public teamId: string;
+
+    @Parameter({
+        description: "Name of the team",
+    })
+    public teamName: string;
 
     @Parameter({
         description: "Membership request id",
@@ -77,13 +82,13 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
                             this.userSlackId)
                             .then(() => {
                                 const msg: SlackMessage = {
-                                    text: `Welcome to the team *${this.userScreenName}*!`,
+                                    text: `Welcome to the team *@${this.userScreenName}*!`,
                                 };
 
                                 return ctx.messageClient.addressChannels(msg, this.teamChannel);
                             }, reason => logger.error(reason));
                     } else {
-                        return ctx.messageClient.send(`Your membership request to team '${this.teamChannel}' has been rejected by @${this.approverUserName}`,
+                        return ctx.messageClient.send(`Your membership request to team '${this.teamName}' has been rejected by @${this.approverUserName}`,
                             addressSlackUsers(config.get("teamId"), this.userScreenName))
                             .then(() => {
                                 return ctx.messageClient.addressChannels("Membership request rejected", this.teamChannel);

--- a/src/gluon/team/MembershipRequestCreated.ts
+++ b/src/gluon/team/MembershipRequestCreated.ts
@@ -62,6 +62,7 @@ export class MembershipRequestCreated implements HandleEvent<any> {
                                 {
                                     membershipRequestId: membershipRequestCreatedEvent.membershipRequestId,
                                     teamId: membershipRequestCreatedEvent.team.teamId,
+                                    teamName: membershipRequestCreatedEvent.team.name,
                                     userScreenName: membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName,
                                     userSlackId: membershipRequestCreatedEvent.requestedBy.slackIdentity.userId,
                                     approvalStatus: "APPROVED",
@@ -72,6 +73,7 @@ export class MembershipRequestCreated implements HandleEvent<any> {
                                 {
                                     membershipRequestId: membershipRequestCreatedEvent.membershipRequestId,
                                     teamId: membershipRequestCreatedEvent.team.teamId,
+                                    teamName: membershipRequestCreatedEvent.team.name,
                                     userScreenName: membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName,
                                     userSlackId: membershipRequestCreatedEvent.requestedBy.slackIdentity.userId,
                                     approvalStatus: "REJECTED",

--- a/src/gluon/team/MembershipRequestCreated.ts
+++ b/src/gluon/team/MembershipRequestCreated.ts
@@ -1,0 +1,87 @@
+import {
+    EventFired,
+    EventHandler,
+    failure,
+    HandleEvent,
+    HandlerContext,
+    HandlerResult,
+    logger,
+    success,
+} from "@atomist/automation-client";
+import {
+    addressSlackUsers,
+    buttonForCommand,
+} from "@atomist/automation-client/spi/message/MessageClient";
+import {SlackMessage} from "@atomist/slack-messages";
+import * as config from "config";
+import {MembershipRequestClosed} from "./MembershipRequestClosed";
+
+@EventHandler("Receive MembershipRequestCreated events", `
+subscription MembershipRequestCreatedEvent {
+  MembershipRequestCreatedEvent {
+    id
+    membershipRequestId
+    team {
+      teamId
+      name
+      slackIdentity {
+        teamChannel
+      }
+    }
+    requestedBy {
+      firstName
+      slackIdentity {
+        screenName
+        userId
+      }
+    }
+  }
+}
+`)
+export class MembershipRequestCreated implements HandleEvent<any> {
+
+    public handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info(`Ingested MembershipRequestCreated event: ${JSON.stringify(event.data)}`);
+
+        const membershipRequestCreatedEvent = event.data.MembershipRequestCreatedEvent[0];
+        return ctx.messageClient.send(`A membership request to team '${membershipRequestCreatedEvent.team.name}' has been sent for approval`,
+            addressSlackUsers(config.get("teamId"), membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName))
+            .then(() => {
+                logger.info("Team: " + membershipRequestCreatedEvent.team.slackIdentity.teamChannel);
+                const msg: SlackMessage = {
+                    text: `User @${membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName} has requested to be added as a team member.`,
+                    attachments: [{
+                        fallback: `User @${membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName} has requested to be added as a team member`,
+                        text: `
+                        A team owner should approve/reject this user's membership request`,
+                        mrkdwn_in: ["text"],
+                        actions: [
+                            buttonForCommand(
+                                {text: "Accept"},
+                                new MembershipRequestClosed(),
+                                {
+                                    membershipRequestId: membershipRequestCreatedEvent.membershipRequestId,
+                                    teamId: membershipRequestCreatedEvent.team.teamId,
+                                    userScreenName: membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName,
+                                    userSlackId: membershipRequestCreatedEvent.requestedBy.slackIdentity.userId,
+                                    approvalStatus: "APPROVED",
+                                }),
+                            buttonForCommand(
+                                {text: "Reject"},
+                                new MembershipRequestClosed(),
+                                {
+                                    membershipRequestId: membershipRequestCreatedEvent.membershipRequestId,
+                                    teamId: membershipRequestCreatedEvent.team.teamId,
+                                    userScreenName: membershipRequestCreatedEvent.requestedBy.slackIdentity.screenName,
+                                    userSlackId: membershipRequestCreatedEvent.requestedBy.slackIdentity.userId,
+                                    approvalStatus: "REJECTED",
+                                }),
+                        ],
+                    }],
+                };
+                logger.info(membershipRequestCreatedEvent.team.teamChannel);
+                return ctx.messageClient.addressChannels(msg, membershipRequestCreatedEvent.team.slackIdentity.teamChannel).then(success);
+            })
+            .catch(error => failure(error));
+    }
+}

--- a/src/gluon/team/teamIngester.ts
+++ b/src/gluon/team/teamIngester.ts
@@ -133,3 +133,77 @@ export const DevOpsEnvironmentRequestedEvent: Ingester = {
         },
     ],
 };
+
+export const MembershipRequestCreatedEvent: Ingester = {
+    root_type: "MembershipRequestCreatedEvent",
+    types: [
+        {
+            kind: "OBJECT",
+            name: "MembershipRequestCreatedEvent",
+            fields: [
+                {
+                    name: "membershipRequestId",
+                    type: {
+                        kind: "SCALAR",
+                        name: "String",
+                    },
+                },
+                {
+                    name: "team",
+                    type: {
+                        kind: "OBJECT",
+                        name: "Team",
+                    },
+                },
+                {
+                    name: "requestedBy",
+                    type: {
+                        kind: "OBJECT",
+                        name: "RequestedBy",
+                    },
+                },
+            ],
+        },
+        {
+            kind: "OBJECT",
+            name: "RequestedBy",
+            fields: [
+                {
+                    name: "firstName",
+                    type: {
+                        kind: "SCALAR",
+                        name: "String",
+                    },
+                },
+                {
+                    name: "lastName",
+                    type: {
+                        kind: "SCALAR",
+                        name: "String",
+                    },
+                },
+                {
+                    name: "email",
+                    type: {
+                        kind: "SCALAR",
+                        name: "String",
+                    },
+                },
+                {
+                    name: "domainUsername",
+                    type: {
+                        kind: "SCALAR",
+                        name: "String",
+                    },
+                },
+                {
+                    name: "slackIdentity",
+                    type: {
+                        kind: "OBJECT",
+                        name: "SlackIdentity",
+                    },
+                },
+            ],
+        },
+    ],
+};

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -143,6 +143,30 @@ export type _PullRequestImpactOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "i
 /* Ordering Enum for UserJoinedChannel */
 export type _UserJoinedChannelOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "id_asc" | "id_desc";
 
+export namespace Channels {
+  export type Variables = {
+    teamId: string;
+    first: number;
+    offset: number;
+  }
+
+  export type Query = {
+    ChatTeam?: ChatTeam[] | null; 
+  } 
+
+  export type ChatTeam = {
+    channels?: Channels[] | null; 
+  } 
+
+  export type Channels = {
+    repos?: Repos[] | null; 
+  } 
+
+  export type Repos = {
+    name?: string | null; 
+    owner?: string | null; 
+  } 
+}
 export namespace ChatId {
   export type Variables = {
     userId: string;


### PR DESCRIPTION
- Implemented Apply To Team command.
- Added ingester for MembershipRequestCreated event
- Added event handler for MembershipRequestCreated events
- Added MembershipRequestClosed command handler

Conversation flow looks as follows:

## Apply to join team:
<img width="471" alt="screen shot 2018-02-15 at 14 04 00" src="https://user-images.githubusercontent.com/4415392/36255832-30fde668-1259-11e8-9ab5-9f34404141a2.png">
Upon clicking the `Apply to join a team` button the user is presented with a list of available teams to join. The user selects one and is notified that a request has been sent to the team for approval.

## Request displayed in team channel
<img width="481" alt="screen shot 2018-02-15 at 14 06 56" src="https://user-images.githubusercontent.com/4415392/36255953-a37e48e0-1259-11e8-82ab-006a683d5db4.png">
The team is notified that the user has applied for membership. Only an owner of the team can approve or reject the request.

### Reject Request
<img width="825" alt="screen shot 2018-02-15 at 15 06 43" src="https://user-images.githubusercontent.com/4415392/36258073-0a015762-1262-11e8-97a9-c12fd3c6f6ec.png">

The user is informed their request has been been rejected and a message stating that the request has been rejected is posted in the team channel.

### Approve Request
<img width="581" alt="screen shot 2018-02-15 at 15 38 29" src="https://user-images.githubusercontent.com/4415392/36259308-82e37a30-1266-11e8-93f3-a41e8b0f8803.png">

The user is invited to the team slack channel and atomist sends a welcome message.

Resolves #3 