### PR TITLE
Infer team from channel/menu for DevOps creation

### DIFF
--- a/src/gluon/project/CreateProject.ts
+++ b/src/gluon/project/CreateProject.ts
@@ -14,7 +14,7 @@ import axios from "axios";
 import * as config from "config";
 import * as _ from "lodash";
 import {gluonMemberFromScreenName} from "../member/Members";
-import {teamsWhoScreenNameBelongsToo} from "../team/Teams";
+import {gluonTeamsWhoSlackScreenNameBelongsToo} from "../team/Teams";
 
 @CommandHandler("Create a new project", config.get("subatomic").commandPrefix + " create project")
 export class CreateProject implements HandleCommand<HandlerResult> {
@@ -56,7 +56,7 @@ export class CreateProject implements HandleCommand<HandlerResult> {
                     }), err => logger.warn(err))
                 .then(success);
         } else {
-            return teamsWhoScreenNameBelongsToo(ctx, this.screenName)
+            return gluonTeamsWhoSlackScreenNameBelongsToo(ctx, this.screenName)
                 .then(teams => {
                     return ctx.messageClient.respond({
                         text: "Please select a team you would like to associate this project with",

--- a/src/gluon/team/DevOpsEnvironment.ts
+++ b/src/gluon/team/DevOpsEnvironment.ts
@@ -9,10 +9,15 @@ import {
     Parameter,
     Tags,
 } from "@atomist/automation-client";
+import {menuForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import axios from "axios";
 import * as config from "config";
 import * as _ from "lodash";
 import {gluonMemberFromScreenName} from "../member/Members";
+import {
+    gluonTeamForSlackTeamChannel,
+    gluonTeamsWhoSlackScreenNameBelongsToo,
+} from "./Teams";
 
 @CommandHandler("Check whether to create a new OpenShift DevOps environment or use and existing one", config.get("subatomic").commandPrefix + " request devops environment")
 @Tags("subatomic", "slack", "team", "openshift", "devops")
@@ -21,44 +26,90 @@ export class NewDevOpsEnvironment implements HandleCommand {
     @MappedParameter(MappedParameters.SlackUserName)
     public screenName: string;
 
-    @MappedParameter(MappedParameters.SlackTeam)
-    public teamId: string;
-
     @MappedParameter(MappedParameters.SlackChannelName)
     public teamChannel: string;
 
     @Parameter({
         description: "team name",
         displayable: false,
+        required: false,
     })
     public teamName: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         logger.info(`Creating new DevOps environment for ...`);
 
-        // If teamId is null (i.e. this command is not run from a team channel)
-        // -> Present a list of Teams to create the DevOps environment for
-        // then circle back with one selected and param = teamName;
-        // if member only belongs to one team then just continue...
+        return gluonTeamForSlackTeamChannel(this.teamChannel)
+            .then(team => {
+                return this.requestDevOpsEnvironment(
+                    ctx,
+                    this.screenName,
+                    team.name,
+                    team.slack.teamChannel,
+                );
+            }, () => {
+                if (!_.isEmpty(this.teamName)) {
+                    return this.requestDevOpsEnvironment(
+                        ctx,
+                        this.screenName,
+                        this.teamName,
+                        this.teamChannel,
+                    );
+                } else {
+                    return gluonTeamsWhoSlackScreenNameBelongsToo(ctx, this.screenName)
+                        .then(teams => {
+                            if (teams.length === 1) {
+                                this.teamName = teams[0].name;
+                                return this.handle(ctx);
+                            } else {
+                                return ctx.messageClient.respond({
+                                    text: "Please select a team you would like to create a DevOps environment for",
+                                    attachments: [{
+                                        fallback: "Select a team to create a DevOps project for",
+                                        actions: [
+                                            menuForCommand({
+                                                    text: "Select Team", options:
+                                                        teams.map(team => {
+                                                            return {
+                                                                value: team.name,
+                                                                text: team.name,
+                                                            };
+                                                        }),
+                                                },
+                                                this, "teamName",
+                                                {
+                                                    name: this.teamName,
+                                                }),
+                                        ],
+                                    }],
+                                });
+                            }
+                        });
+                }
+            });
+    }
 
-        return gluonMemberFromScreenName(ctx, this.screenName)
+    private requestDevOpsEnvironment(ctx: HandlerContext, screenName: string,
+                                     teamName: string,
+                                     teamChannel: string): Promise<any> {
+        return gluonMemberFromScreenName(ctx, screenName)
             .then(member => {
-                return axios.get(`http://localhost:8080/teams?name=${this.teamName}`)
+                axios.get(`${config.get("subatomic").gluon.baseUrl}/teams?name=${teamName}`)
                     .then(team => {
                         if (!_.isEmpty(team.data._embedded)) {
-                            return axios.put(`http://localhost:8080/teams/${team.data._embedded.teamResources[0].teamId}`,
+                            return axios.put(`${config.get("subatomic").gluon.baseUrl}/teams/${team.data._embedded.teamResources[0].teamId}`,
                                 {
                                     devOpsEnvironment: {
                                         requestedBy: member.memberId,
                                     },
                                 });
                         }
+                    })
+                    .then(() => {
+                        return ctx.messageClient.addressChannels({
+                            text: `🚀 Your DevOps environment for *${teamName}* team, is being provisioned...`,
+                        }, teamChannel);
                     });
-            })
-            .then(() => {
-                return ctx.messageClient.addressChannels({
-                    text: "🚀 Your team's DevOps environment is being provisioned...",
-                }, this.teamChannel);
             });
     }
 }

--- a/src/gluon/team/Teams.ts
+++ b/src/gluon/team/Teams.ts
@@ -1,18 +1,20 @@
 import {HandlerContext} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import axios from "axios";
+import * as config from "config";
 import * as _ from "lodash";
 import {CreateTeam} from "./CreateTeam";
 import {JoinTeam} from "./JoinTeam";
 
-export function teamsWhoScreenNameBelongsToo(ctx: HandlerContext, screenName: string): Promise<any[]> {
-    return axios.get(`http://localhost:8080/teams?slackScreenName=${screenName}`)
+export function gluonTeamsWhoSlackScreenNameBelongsToo(ctx: HandlerContext, screenName: string): Promise<any[]> {
+    return axios.get(`${config.get("subatomic").gluon.baseUrl}/teams?slackScreenName=${screenName}`)
         .then(teams => {
             if (!_.isEmpty(teams.data._embedded)) {
                 return Promise.resolve(teams.data._embedded.teamResources);
             }
 
             return ctx.messageClient.respond({
+                // TODO this message should be customisable, as this function is used elsewhere
                 text: "Unfortunately, you are not a member of any teams. You must be a member of at least one team to associate this new project too.",
                 attachments: [{
                     text: "You can either create a new team or apply to join an existing team",
@@ -31,5 +33,20 @@ export function teamsWhoScreenNameBelongsToo(ctx: HandlerContext, screenName: st
                 }],
             })
                 .then(() => Promise.reject(`${screenName} does not belong to any teams`));
+        });
+}
+
+export function gluonTeamForSlackTeamChannel(teamChannel: string): Promise<any> {
+    return axios.get(`${config.get("subatomic").gluon.baseUrl}/teams?slackTeamChannel=${teamChannel}`)
+        .then(teams => {
+            if (!_.isEmpty(teams.data._embedded)) {
+                if (teams.data._embedded.teamResources.length === 1) {
+                    return Promise.resolve(teams.data._embedded.teamResources[0]);
+                } else {
+                    throw new RangeError("Multiple teams associated with the same Slack team channel is not expected");
+                }
+            } else {
+                return Promise.reject(`No teams associated with Slack team channel: ${teamChannel}`);
+            }
         });
 }


### PR DESCRIPTION
Depends on https://github.com/absa-subatomic/gluon/pull/24.

When creating a DevOps environment, the team name should not need to be typed.

* if the Slack channel the command was executed in is actually the team's Slack channel, then use the team Id associated with this Slack channel

![devops-in-team-channel-done](https://user-images.githubusercontent.com/1175891/36339086-68bf07e4-13c6-11e8-90c3-cf362249debc.png)

* If the Slack channel is not associated with any teams the member is a part of, then present a menu with the teams that the member is a part of

![devops-multiple-teams](https://user-images.githubusercontent.com/1175891/36339136-25782e7e-13c7-11e8-8449-75cc3439f6b4.png)

![devops-multiple-teams-done](https://user-images.githubusercontent.com/1175891/36339194-7654755e-13c8-11e8-84d3-aaad72bcd4df.png)

* even if the member belongs to multiple teams but sends the command in a Slack channel associated with one of the Teams, then don't present a menu but just use the Team associated with the current channel.

Resolves #6 



