### PR TITLE
Infer team from channel command was issued from

### DIFF
--- a/src/gluon/project/CreateProject.ts
+++ b/src/gluon/project/CreateProject.ts
@@ -3,24 +3,28 @@ import {
     HandleCommand,
     HandlerContext,
     HandlerResult,
-    logger,
     MappedParameter,
     MappedParameters,
     Parameter,
-    success,
 } from "@atomist/automation-client";
 import {menuForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import axios from "axios";
 import * as config from "config";
 import * as _ from "lodash";
 import {gluonMemberFromScreenName} from "../member/Members";
-import {gluonTeamsWhoSlackScreenNameBelongsToo} from "../team/Teams";
+import {
+    gluonTeamForSlackTeamChannel,
+    gluonTeamsWhoSlackScreenNameBelongsToo,
+} from "../team/Teams";
 
 @CommandHandler("Create a new project", config.get("subatomic").commandPrefix + " create project")
 export class CreateProject implements HandleCommand<HandlerResult> {
 
     @MappedParameter(MappedParameters.SlackUserName)
     public screenName: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public teamChannel: string;
 
     @Parameter({
         description: "project name",
@@ -40,49 +44,71 @@ export class CreateProject implements HandleCommand<HandlerResult> {
     public teamName: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-        // ask which team to assign to this project too
-        // you must belong to those teams
-        if (!_.isEmpty(this.teamName)) {
-            return gluonMemberFromScreenName(ctx, this.screenName,
-                `There was an error creating your ${this.name} project`)
-                .then(member => axios.post("http://localhost:8080/projects",
-                    {
-                        name: this.name,
-                        description: this.description,
-                        createdBy: member.memberId,
-                        teams: [{
-                            teamId: this.teamName,
-                        }],
-                    }), err => logger.warn(err))
-                .then(success);
-        } else {
-            return gluonTeamsWhoSlackScreenNameBelongsToo(ctx, this.screenName)
-                .then(teams => {
-                    return ctx.messageClient.respond({
-                        text: "Please select a team you would like to associate this project with",
-                        attachments: [{
-                            fallback: "Select a team to associate this new project with",
-                            actions: [
-                                menuForCommand({
-                                        text: "Select Team", options:
-                                            teams.map(team => {
-                                                return {
-                                                    // TODO use Id when name is actually hinted at by the param
-                                                    // may want to clean this up later
-                                                    value: team.teamId,
-                                                    text: team.name,
-                                                };
+        return gluonTeamForSlackTeamChannel(this.teamChannel)
+            .then(team => {
+                return this.requestNewProject(
+                    ctx,
+                    this.screenName,
+                    team.name,
+                    team.slack.teamChannel,
+                );
+            }, () => {
+                if (!_.isEmpty(this.teamName)) {
+                    return this.requestNewProject(
+                        ctx,
+                        this.screenName,
+                        this.teamName,
+                        this.teamChannel,
+                    );
+                } else {
+                    return gluonTeamsWhoSlackScreenNameBelongsToo(ctx, this.screenName)
+                        .then(teams => {
+                            return ctx.messageClient.respond({
+                                text: "Please select a team you would like to associate this project with",
+                                attachments: [{
+                                    fallback: "Select a team to associate this new project with",
+                                    actions: [
+                                        menuForCommand({
+                                                text: "Select Team", options:
+                                                    teams.map(team => {
+                                                        return {
+                                                            value: team.name,
+                                                            text: team.name,
+                                                        };
+                                                    }),
+                                            },
+                                            this, "teamName",
+                                            {
+                                                name: this.name,
+                                                description: this.description,
                                             }),
-                                    },
-                                    this, "teamName",
-                                    {
-                                        name: this.name,
-                                        description: this.description,
-                                    }),
-                            ],
-                        }],
+                                    ],
+                                }],
+                            });
+                        });
+                }
+            });
+    }
+
+    private requestNewProject(ctx: HandlerContext, screenName: string,
+                              teamName: string,
+                              teamChannel: string): Promise<any> {
+        return gluonMemberFromScreenName(ctx, screenName)
+            .then(member => {
+                axios.get(`${config.get("subatomic").gluon.baseUrl}/teams?name=${teamName}`)
+                    .then(team => {
+                        if (!_.isEmpty(team.data._embedded)) {
+                            return axios.post(`${config.get("subatomic").gluon.baseUrl}/projects`,
+                                {
+                                    name: this.name,
+                                    description: this.description,
+                                    createdBy: member.memberId,
+                                    teams: [{
+                                        teamId: team.data._embedded.teamResources[0].teamId,
+                                    }],
+                                });
+                        }
                     });
-                }, err => logger.warn(err));
-        }
+            });
     }
 }

--- a/src/gluon/project/ProjectCreated.ts
+++ b/src/gluon/project/ProjectCreated.ts
@@ -47,7 +47,7 @@ export class ProjectCreated implements HandleEvent<any> {
 
         const projectCreatedEvent = event.data.ProjectCreatedEvent[0];
         return ctx.messageClient.addressChannels({
-            text: `The ${projectCreatedEvent.project.name} project has been created successfully.`,
+            text: `The *${projectCreatedEvent.project.name}* project has been created successfully.`,
             attachments: [{
                 text: `
 A Subatomic project is linked to a Bitbucket project. \

--- a/src/gluon/project/ProjectCreated.ts
+++ b/src/gluon/project/ProjectCreated.ts
@@ -8,6 +8,7 @@ import {
 } from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {url} from "@atomist/slack-messages";
+import * as config from "config";
 import {
     ListExistingBitbucketProject,
     NewBitbucketProject,
@@ -46,13 +47,13 @@ export class ProjectCreated implements HandleEvent<any> {
 
         const projectCreatedEvent = event.data.ProjectCreatedEvent[0];
         return ctx.messageClient.addressChannels({
-            text: `The ${projectCreatedEvent.project.name} project has been created successfully by @${projectCreatedEvent.createdBy.slackIdentity.screenName} 👍`,
+            text: `The ${projectCreatedEvent.project.name} project has been created successfully.`,
             attachments: [{
                 text: `
 A Subatomic project is linked to a Bitbucket project. \
 This can be a new Bitbucket project that will be created and configured according to best practice or you can choose to link an existing project. The existing project will also be configured accordingly.`,
                 fallback: "Create or link Bitbucket project",
-                footer: `For more information, please read the ${this.docs()}`, // TODO use actual icon
+                footer: `For more information, please read the ${this.docs()}`,
                 color: "#45B254",
                 actions: [
                     buttonForCommand(
@@ -73,7 +74,7 @@ A Subatomic project is deployed into the OpenShift platform. \
 The platform consists of two clusters, an Non Prod and a Prod cluster. The project environments span both clusters and are the deployment targets for the applications managed by Subatomic.
 These environments are realised as OpenShift projects and need to be created or linked to existing projects. If you haven't done either, please do that now.`,
                 fallback: "Create or link existing OpenShift environments",
-                footer: `For more information, please read the ${this.docs()}`, // TODO use actual icon
+                footer: `For more information, please read the ${this.docs()}`,
                 color: "#45B254",
                 actions: [
                     buttonForCommand(
@@ -88,14 +89,14 @@ These environments are realised as OpenShift projects and need to be created or 
 Projects can be associated with multiple teams. \
 If you would like to associate more teams to the *${projectCreatedEvent.project.name}* project, please use the \`@atomist subatomic associate team\` command`,
                 fallback: "Associate multiple teams to this project",
-                footer: `For more information, please read the ${this.docs()}`, // TODO use actual icon
+                footer: `For more information, please read the ${this.docs()}`,
                 color: "#00a5ff",
             }],
         }, projectCreatedEvent.team.slackIdentity.teamChannel);
     }
 
     private docs(): string {
-        return `${url("https://subatomic.bison.absa.co.za/docs/projects",
+        return `${url(`${config.get("subatomic").docs.baseUrl}/projects`,
             "documentation")}`;
     }
 }

--- a/src/gluon/team/DevOpsEnvironment.ts
+++ b/src/gluon/team/DevOpsEnvironment.ts
@@ -37,8 +37,6 @@ export class NewDevOpsEnvironment implements HandleCommand {
     public teamName: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-        logger.info(`Creating new DevOps environment for ...`);
-
         return gluonTeamForSlackTeamChannel(this.teamChannel)
             .then(team => {
                 return this.requestDevOpsEnvironment(


### PR DESCRIPTION
When creating a new Gluon project:

* when executing the create project command in the Team Slack channel (`demo` in the screenshots below), the Team associated with this channel should be used as the Team to add this new Project too

![project-inside-team-channel-1](https://user-images.githubusercontent.com/1175891/36349424-3a72760e-148f-11e8-9965-416441de0a26.png)

* when not on a Team channel, then present a menu with Teams that the member is a part of, on selection of the Team then use that Team (this is what currently happens regardless of Slack channel)

![project-outside-team-channel](https://user-images.githubusercontent.com/1175891/36349398-97d34a68-148e-11e8-9ca8-460143aca5a8.png)

Resolves #39