### PR TITLE
Menu selection for linking team to channel

### DIFF
--- a/src/gluon/project/CreateProject.ts
+++ b/src/gluon/project/CreateProject.ts
@@ -14,7 +14,7 @@ import {QMConfig} from "../../config/QMConfig";
 import {gluonMemberFromScreenName} from "../member/Members";
 import {
     gluonTeamForSlackTeamChannel,
-    gluonTeamsWhoSlackScreenNameBelongsToo,
+    gluonTeamsWhoSlackScreenNameBelongsTo,
 } from "../team/Teams";
 
 @CommandHandler("Create a new project", QMConfig.subatomic.commandPrefix + " create project")
@@ -61,7 +61,7 @@ export class CreateProject implements HandleCommand<HandlerResult> {
                         this.teamChannel,
                     );
                 } else {
-                    return gluonTeamsWhoSlackScreenNameBelongsToo(ctx, this.screenName)
+                    return gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName)
                         .then(teams => {
                             return ctx.messageClient.respond({
                                 text: "Please select a team you would like to associate this project with",

--- a/src/gluon/team/DevOpsEnvironment.ts
+++ b/src/gluon/team/DevOpsEnvironment.ts
@@ -3,7 +3,6 @@ import {
     HandleCommand,
     HandlerContext,
     HandlerResult,
-    logger,
     MappedParameter,
     MappedParameters,
     Parameter,
@@ -16,7 +15,7 @@ import {QMConfig} from "../../config/QMConfig";
 import {gluonMemberFromScreenName} from "../member/Members";
 import {
     gluonTeamForSlackTeamChannel,
-    gluonTeamsWhoSlackScreenNameBelongsToo,
+    gluonTeamsWhoSlackScreenNameBelongsTo,
 } from "./Teams";
 
 @CommandHandler("Check whether to create a new OpenShift DevOps environment or use and existing one", QMConfig.subatomic.commandPrefix + " request devops environment")
@@ -54,7 +53,7 @@ export class NewDevOpsEnvironment implements HandleCommand {
                         this.teamChannel,
                     );
                 } else {
-                    return gluonTeamsWhoSlackScreenNameBelongsToo(ctx, this.screenName)
+                    return gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName)
                         .then(teams => {
                             if (teams.length === 1) {
                                 this.teamName = teams[0].name;

--- a/src/gluon/team/Teams.ts
+++ b/src/gluon/team/Teams.ts
@@ -6,7 +6,7 @@ import {QMConfig} from "../../config/QMConfig";
 import {CreateTeam} from "./CreateTeam";
 import {JoinTeam} from "./JoinTeam";
 
-export function gluonTeamsWhoSlackScreenNameBelongsToo(ctx: HandlerContext, screenName: string): Promise<any[]> {
+export function gluonTeamsWhoSlackScreenNameBelongsTo(ctx: HandlerContext, screenName: string): Promise<any[]> {
     return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?slackScreenName=${screenName}`)
         .then(teams => {
             if (!_.isEmpty(teams.data._embedded)) {


### PR DESCRIPTION
Added menu selection for link to existing slack channel to gluon team being called from intent.

Resolves #24 