### PR TITLE
Re-authorize OpenShift client before starting a set of OpenShift commands

### DIFF
--- a/src/config/OpenShiftConfig.ts
+++ b/src/config/OpenShiftConfig.ts
@@ -1,0 +1,8 @@
+export interface OpenShiftConfig {
+    masterUrl: string;
+    auth: OpenShiftAuth;
+}
+
+export interface OpenShiftAuth {
+    token: string;
+}

--- a/src/config/OpenshiftConfig.ts
+++ b/src/config/OpenshiftConfig.ts
@@ -1,8 +1,0 @@
-export interface OpenshiftConfig {
-    masterUrl: string;
-    auth: OpenshiftAuth;
-}
-
-export interface OpenshiftAuth {
-    token: string;
-}

--- a/src/config/OpenshiftConfig.ts
+++ b/src/config/OpenshiftConfig.ts
@@ -1,0 +1,8 @@
+export interface OpenshiftConfig {
+    masterUrl: string;
+    auth: OpenshiftAuth;
+}
+
+export interface OpenshiftAuth {
+    token: string;
+}

--- a/src/config/SubatomicConfig.ts
+++ b/src/config/SubatomicConfig.ts
@@ -1,11 +1,12 @@
 import {BitbucketConfig} from "./BitbucketConfig";
 import {DocsConfig} from "./DocsConfig";
 import {GluonConfig} from "./GluonConfig";
+import {OpenshiftConfig} from "./OpenshiftConfig";
 
 export interface SubatomicConfig {
     bitbucket: BitbucketConfig;
     commandPrefix: string;
     docs: DocsConfig;
     gluon: GluonConfig;
-    openshiftHost: string;
+    openshift: OpenshiftConfig;
 }

--- a/src/config/SubatomicConfig.ts
+++ b/src/config/SubatomicConfig.ts
@@ -1,12 +1,12 @@
 import {BitbucketConfig} from "./BitbucketConfig";
 import {DocsConfig} from "./DocsConfig";
 import {GluonConfig} from "./GluonConfig";
-import {OpenshiftConfig} from "./OpenshiftConfig";
+import {OpenShiftConfig} from "./OpenShiftConfig";
 
 export interface SubatomicConfig {
     bitbucket: BitbucketConfig;
     commandPrefix: string;
     docs: DocsConfig;
     gluon: GluonConfig;
-    openshift: OpenshiftConfig;
+    openshift: OpenShiftConfig;
 }

--- a/src/gluon/project/ProjectEnvironmentsRequested.ts
+++ b/src/gluon/project/ProjectEnvironmentsRequested.ts
@@ -77,9 +77,12 @@ export class ProjectEnvironmentsRequested implements HandleEvent<any> {
                 const projectId = `${_.kebabCase(environmentsRequestedEvent.project.name).toLowerCase()}-${environment[0]}`;
                 logger.info(`Working with OpenShift project Id: ${projectId}`);
 
-                return OCClient.newProject(projectId,
-                    `${environmentsRequestedEvent.project.name} ${environment[0].toUpperCase()}`,
-                    `${environment[1]} environment for ${environmentsRequestedEvent.project.name} [managed by Subatomic]`)
+                return OCClient.login(QMConfig.subatomic.openshift.masterUrl, QMConfig.subatomic.openshift.auth.token)
+                    .then(() => {
+                        return OCClient.newProject(projectId,
+                            `${environmentsRequestedEvent.project.name} ${environment[0].toUpperCase()}`,
+                            `${environment[1]} environment for ${environmentsRequestedEvent.project.name} [managed by Subatomic]`);
+                    })
                     .then(() => {
                         // 2. Add permissions to projects based on owners (admin) and members (edit) - future will use roles
                         return this.addMembershipPermissions(projectId,
@@ -159,7 +162,7 @@ export class ProjectEnvironmentsRequested implements HandleEvent<any> {
                                     [
                                         new SimpleOption("-namespace", projectId),
                                     ]
-                                    , );
+                                    ,);
                             });
                     })
                     .then(() => {

--- a/src/gluon/project/ProjectEnvironmentsRequested.ts
+++ b/src/gluon/project/ProjectEnvironmentsRequested.ts
@@ -162,7 +162,7 @@ export class ProjectEnvironmentsRequested implements HandleEvent<any> {
                                     [
                                         new SimpleOption("-namespace", projectId),
                                     ]
-                                    ,);
+                                    , );
                             });
                     })
                     .then(() => {

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -65,9 +65,12 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
         const projectId = `${_.kebabCase(devOpsRequestedEvent.team.name).toLowerCase()}-devops`;
         logger.info(`Working with OpenShift project Id: ${projectId}`);
 
-        return OCClient.newProject(projectId,
-            `${devOpsRequestedEvent.team.name} DevOps`,
-            `DevOps environment for ${devOpsRequestedEvent.team.name} [managed by Subatomic]`)
+        return OCClient.login(QMConfig.subatomic.openshift.masterUrl, QMConfig.subatomic.openshift.auth.token)
+            .then(() => {
+                return OCClient.newProject(projectId,
+                    `${devOpsRequestedEvent.team.name} DevOps`,
+                    `DevOps environment for ${devOpsRequestedEvent.team.name} [managed by Subatomic]`);
+            })
             .then(() => {
                 return this.addMembershipPermissions(projectId,
                     devOpsRequestedEvent.team);
@@ -143,7 +146,7 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                             [
                                 new SimpleOption("-namespace", projectId),
                             ]
-                            , );
+                            ,);
                     });
             }).then(() => {
                 return Promise.all([OCCommon.commonCommand("tag",

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -146,7 +146,7 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                             [
                                 new SimpleOption("-namespace", projectId),
                             ]
-                            ,);
+                            , );
                     });
             }).then(() => {
                 return Promise.all([OCCommon.commonCommand("tag",


### PR DESCRIPTION
Adding OCClient.login calls before starting current OpenShift command sets to ensure the client is still authorised. 

Left this as a simple implementation for now since this will change when moving to either Api calls or ansible playbooks.

Resolves #53 