### PR TITLE
Use build() to construct the actual command value

### DIFF
--- a/src/openshift/base/OCCommand.ts
+++ b/src/openshift/base/OCCommand.ts
@@ -26,7 +26,7 @@ export class OCCommand implements CommandLineElement {
         const command = this.build();
 
         return new Promise((resolve, reject) => {
-            logger.debug(`Executing oc command: ${command}`);
+            logger.verbose(`Executing oc command: ${command}`);
             try {
                 const execution: any = require("child_process").execSync(command);
                 // exec(command, (error: any, inherit: string) => {
@@ -54,7 +54,7 @@ export class OCCommand implements CommandLineElement {
         let commandString = this.buildBaseCommand();
         for (const option of this.options) {
             if (option) {
-                commandString += `${option.buildDisplayCommand()} `;
+                commandString += `${option.build()} `;
             }
         }
 


### PR DESCRIPTION
Correctly uses the `build()` method to construct the actual command options.

```console
xxx [m:92544:aef3204f-41e1-4764-96d9-63cc5d282490:core-atomist:DevOpsEnvironmentRequestedEvent:003] [verbose] Executing oc command: oc login "https://192.168.64.15:8443" --token="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJzdWJhdG9taWMiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlY3JldC5uYW1lIjoic3ViYXRvbWljLXRva2VuLWM1Y2duIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6InN1YmF0b21pYyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjEzNGEzOTczLTE2ZDItMTFlOC04Y2EzLTY2NTBmNzRlMTY0MyIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpzdWJhdG9taWM6c3ViYXRvbWljIn0.pIGkjUfDiBbgohNu_G2WELT9ocdoI5BVobiGoC1rIJvIUFcsZtNyKTEmtX7y8daM6roF4tsCzkQBhTntW0KV21c0i1nbITEkgbcSV9qaTYDbatqJZX34AaN9fDA6KvnGSMa0WXOJBXfglBudCO4cnqYrb-u-lgzn1HuvHD8o4EiCmZAJFHNTVPoguYj8T-e5HVSJwQGoT9RXemqcffFM50TprtEhFNxKjVEsOEiz-fa96sxD_ZgR8BejVrbUe3Iei2beT4i-_bcL7Dt9x5QUHeln2VkGCF2gm-BGHO0gzyWjXR9fTY0MLNyc3hz8UiZmtWsnWZ6kkrCqWLXOgPDOeA"
xxx [m:92544:aef3204f-41e1-4764-96d9-63cc5d282490:core-atomist:DevOpsEnvironmentRequestedEvent:1046] [debug] OpenShift client response: {"command":"oc login \"https://192.168.64.15:8443\" --token=\"*secret*\" ","output":"Logged into \"https://192.168.64.15:8443\" as \"system:serviceaccount:subatomic:subatomic\" using the token provided.\n\nYou have access to the following projects and can switch between them with 'oc project <projectname>':\n\n  * default\n    kube-public\n    kube-system\n    myproject\n    openshift\n    openshift-infra\n    openshift-node\n    subatomic\n    subatomic-infra\n\nUsing project \"default\".\n","status":true}
```

Fixes #66