### PR TITLE
Added the bitbucket key to the project request

### DIFF
--- a/src/gluon/bitbucket/BitbucketProject.ts
+++ b/src/gluon/bitbucket/BitbucketProject.ts
@@ -130,6 +130,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
                                             bitbucketProject: {
                                                 name: project.data.name,
                                                 description: project.data.description,
+                                                key: this.bitbucketProjectKey,
                                             },
                                             createdBy: member.memberId,
                                         });


### PR DESCRIPTION
Bitbucket project requests when linking an existing repository will now include the existing key.