### PR TITLE
Newly Added Team Member Permission Fix

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -51,7 +51,7 @@ import {MembershipRequestClosed} from "./gluon/team/MembershipRequestClosed";
 import {MembershipRequestCreated} from "./gluon/team/MembershipRequestCreated";
 import {TeamCreated} from "./gluon/team/TeamCreated";
 import {
-    DevOpsEnvironmentRequestedEvent,
+    DevOpsEnvironmentRequestedEvent, MembersAddedToTeamEvent,
     MembershipRequestCreatedEvent,
     TeamCreatedEvent,
 } from "./gluon/team/teamIngester";
@@ -119,6 +119,7 @@ export const configuration: any = {
         Project,
         BitbucketProject,
         ActionedBy,
+        MembersAddedToTeamEvent,
     ],
     token,
     http: {

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -47,11 +47,13 @@ import {
     CreateMembershipRequestToTeam,
     JoinTeam,
 } from "./gluon/team/JoinTeam";
+import {MembersAddedToTeam} from "./gluon/team/MembersAddedToTeam";
 import {MembershipRequestClosed} from "./gluon/team/MembershipRequestClosed";
 import {MembershipRequestCreated} from "./gluon/team/MembershipRequestCreated";
 import {TeamCreated} from "./gluon/team/TeamCreated";
 import {
-    DevOpsEnvironmentRequestedEvent, MembersAddedToTeamEvent,
+    DevOpsEnvironmentRequestedEvent,
+    MembersAddedToTeamEvent,
     MembershipRequestCreatedEvent,
     TeamCreatedEvent,
 } from "./gluon/team/teamIngester";
@@ -103,6 +105,7 @@ export const configuration: any = {
         ApplicationCreated,
         MembershipRequestCreated,
         BotJoinedChannel,
+        MembersAddedToTeam,
     ],
     ingesters: [
         SlackIdentity,

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -7,26 +7,26 @@ import {
     ListExistingBitbucketProject,
     NewBitbucketProject,
 } from "./gluon/bitbucket/BitbucketProject";
-import { BitbucketProjectAdded } from "./gluon/bitbucket/BitbucketProjectAdded";
-import { BitbucketProjectRequested } from "./gluon/bitbucket/BitbucketProjectRequested";
-import { KickOffJenkinsBuild } from "./gluon/jenkins/JenkinsBuild";
-import { OnboardMember } from "./gluon/member/Onboard";
-import { AddSlackDetails, Whoami } from "./gluon/member/Slack";
-import { TeamMemberCreated } from "./gluon/member/TeamMemberCreated";
-import { TeamMemberCreatedEvent } from "./gluon/member/teamMemberIngester";
-import { ApplicationCreated } from "./gluon/packages/ApplicationCreated";
-import { ApplicationCreatedEvent } from "./gluon/packages/applicationsIngester";
+import {BitbucketProjectAdded} from "./gluon/bitbucket/BitbucketProjectAdded";
+import {BitbucketProjectRequested} from "./gluon/bitbucket/BitbucketProjectRequested";
+import {KickOffJenkinsBuild} from "./gluon/jenkins/JenkinsBuild";
+import {OnboardMember} from "./gluon/member/Onboard";
+import {AddSlackDetails, Whoami} from "./gluon/member/Slack";
+import {TeamMemberCreated} from "./gluon/member/TeamMemberCreated";
+import {TeamMemberCreatedEvent} from "./gluon/member/teamMemberIngester";
+import {ApplicationCreated} from "./gluon/packages/ApplicationCreated";
+import {ApplicationCreatedEvent} from "./gluon/packages/applicationsIngester";
 import {
     CreateApplication,
     LinkExistingApplication,
 } from "./gluon/packages/CreateApplication";
-import { LinkExistingLibrary } from "./gluon/packages/CreateLibrary";
-import { AddConfigServer } from "./gluon/project/AddConfigServer";
-import { CreateOpenShiftPvc } from "./gluon/project/CreateOpenShiftPvc";
-import { CreateProject } from "./gluon/project/CreateProject";
-import { ProjectCreated } from "./gluon/project/ProjectCreated";
-import { NewProjectEnvironments } from "./gluon/project/ProjectEnvironments";
-import { ProjectEnvironmentsRequested } from "./gluon/project/ProjectEnvironmentsRequested";
+import {LinkExistingLibrary} from "./gluon/packages/CreateLibrary";
+import {AddConfigServer} from "./gluon/project/AddConfigServer";
+import {CreateOpenShiftPvc} from "./gluon/project/CreateOpenShiftPvc";
+import {CreateProject} from "./gluon/project/CreateProject";
+import {ProjectCreated} from "./gluon/project/ProjectCreated";
+import {NewProjectEnvironments} from "./gluon/project/ProjectEnvironments";
+import {ProjectEnvironmentsRequested} from "./gluon/project/ProjectEnvironmentsRequested";
 import {
     ProjectCreatedEvent,
     ProjectEnvironmentsRequestedEvent,
@@ -47,9 +47,9 @@ import {
     CreateMembershipRequestToTeam,
     JoinTeam,
 } from "./gluon/team/JoinTeam";
-import { MembershipRequestClosed } from "./gluon/team/MembershipRequestClosed";
-import { MembershipRequestCreated } from "./gluon/team/MembershipRequestCreated";
-import { TeamCreated } from "./gluon/team/TeamCreated";
+import {MembershipRequestClosed} from "./gluon/team/MembershipRequestClosed";
+import {MembershipRequestCreated} from "./gluon/team/MembershipRequestCreated";
+import {TeamCreated} from "./gluon/team/TeamCreated";
 import {
     DevOpsEnvironmentRequestedEvent,
     MembershipRequestCreatedEvent,

--- a/src/gluon/bitbucket/BitbucketProject.ts
+++ b/src/gluon/bitbucket/BitbucketProject.ts
@@ -130,6 +130,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
                                             bitbucketProject: {
                                                 name: project.data.name,
                                                 description: project.data.description,
+                                                key: this.bitbucketProjectKey,
                                             },
                                             createdBy: member.memberId,
                                         });

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -148,7 +148,7 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                             [
                                 new SimpleOption("-namespace", projectId),
                             ]
-                            ,);
+                            , );
                     });
             }).then(() => {
                 return Promise.all([OCCommon.commonCommand("tag",

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -74,14 +74,14 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                     `DevOps environment for ${devOpsRequestedEvent.team.name} [managed by Subatomic]`);
             })
             .then(() => {
-                return this.addMembershipPermissions(projectId,
+                return addOpenshiftMembershipPermissions(projectId,
                     devOpsRequestedEvent.team);
             }, err => {
                 logger.warn(err);
                 // TODO what do we do with existing projects?
                 // We should probably make sure the name, display name etc. is consistent
 
-                return this.addMembershipPermissions(projectId,
+                return addOpenshiftMembershipPermissions(projectId,
                     devOpsRequestedEvent.team);
             })
             .then(() => {
@@ -148,7 +148,7 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                             [
                                 new SimpleOption("-namespace", projectId),
                             ]
-                            , );
+                            ,);
                     });
             }).then(() => {
                 return Promise.all([OCCommon.commonCommand("tag",
@@ -397,29 +397,29 @@ If your applications will require a Spring Cloud Config Server, you can add a Su
             });
     }
 
-    private addMembershipPermissions(projectId: string, team: any): Promise<any> {
-        return Promise.all(
-            team.owners.map(owner => {
-                const ownerUsername = /[^\\]*$/.exec(owner.domainUsername)[0];
-                logger.info(`Adding role to project [${projectId}] and owner [${owner.domainUsername}]: ${ownerUsername}`);
-                return OCClient.policy.addRoleToUser(ownerUsername,
-                    "admin",
-                    projectId);
-            }))
-            .then(() => {
-                return Promise.all(
-                    team.members.map(member => {
-                        const memberUsername = /[^\\]*$/.exec(member.domainUsername)[0];
-                        logger.info(`Adding role to project [${projectId}] and member [${member.domainUsername}]: ${memberUsername}`);
-                        return OCClient.policy.addRoleToUser(memberUsername,
-                            "view",
-                            projectId);
-                    }));
-            });
-    }
-
     private docs(): string {
         return `${url(`${QMConfig.subatomic.docs.baseUrl}/devops`,
             "documentation")}`;
     }
+}
+
+export function addOpenshiftMembershipPermissions(projectId: string, team: { owners: Array<{ domainUsername }>, members: Array<{ domainUsername }> }): Promise<any> {
+    return Promise.all(
+        team.owners.map(owner => {
+            const ownerUsername = /[^\\]*$/.exec(owner.domainUsername)[0];
+            logger.info(`Adding role to project [${projectId}] and owner [${owner.domainUsername}]: ${ownerUsername}`);
+            return OCClient.policy.addRoleToUser(ownerUsername,
+                "admin",
+                projectId);
+        }))
+        .then(() => {
+            return Promise.all(
+                team.members.map(member => {
+                    const memberUsername = /[^\\]*$/.exec(member.domainUsername)[0];
+                    logger.info(`Adding role to project [${projectId}] and member [${member.domainUsername}]: ${memberUsername}`);
+                    return OCClient.policy.addRoleToUser(memberUsername,
+                        "view",
+                        projectId);
+                }));
+        });
 }

--- a/src/gluon/team/MembersAddedToTeam.ts
+++ b/src/gluon/team/MembersAddedToTeam.ts
@@ -1,0 +1,81 @@
+import {
+    EventFired,
+    EventHandler,
+    HandleEvent,
+    HandlerContext,
+    HandlerResult,
+    logger,
+} from "@atomist/automation-client";
+import * as _ from "lodash";
+import {BitbucketConfiguration} from "../bitbucket/BitbucketConfiguration";
+import {gluonProjectsWhichBelongToGluonTeam} from "../project/Projects";
+import {addOpenshiftMembershipPermissions} from "./DevOpsEnvironmentRequested";
+
+@EventHandler("Receive MembershipRequestCreated events", `
+subscription MembersAddedToTeamEvent {
+  MembersAddedToTeamEvent {
+    team {
+      teamId
+      name
+      slackIdentity {
+        teamChannel
+      }
+    }
+    owners{
+      firstName
+      slackIdentity {
+        screenName
+        userId
+      }
+    }
+    members{
+      firstName
+      domainUsername
+      slackIdentity {
+        screenName
+        userId
+      }
+    }
+  }
+}
+`)
+export class MembersAddedToTeam implements HandleEvent<any> {
+
+    public handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info(`Ingested MembersAddedToTeamEvent event: ${JSON.stringify(event.data)}`);
+
+        const membersAddedToTeamEvent = event.data.membersAddedToTeamEvent[0];
+        const team = membersAddedToTeamEvent.team;
+
+        return gluonProjectsWhichBelongToGluonTeam(ctx, team.name).then(projects => {
+                let teamOwnersUsernames: string[] = [];
+                let teamMembersUsernames: string[] = [];
+
+                teamOwnersUsernames = _.union(teamOwnersUsernames, team.owners.map(owner => owner.domainUsername));
+                teamMembersUsernames = _.union(teamMembersUsernames, team.members.map(member => member.domainUsername));
+                const bitbucketConfiguration = new BitbucketConfiguration(teamOwnersUsernames, teamMembersUsernames);
+
+                const permissionPromises: Array<Promise<any>> = [];
+                const devopsProject = `${_.kebabCase(team.name).toLowerCase()}-devops`;
+                permissionPromises.push(addOpenshiftMembershipPermissions(devopsProject, team));
+                for (const project of projects) {
+                    // Add to bitbucket
+                    permissionPromises.push(
+                        bitbucketConfiguration.configureBitbucketProject(project.key),
+                    );
+                    // Add to openshift environments
+                    for (const environment of ["dev", "sit", "uat"]) {
+                        const projectId = `${_.kebabCase(project.name).toLowerCase()}-${environment}`;
+                        permissionPromises.push(
+                            addOpenshiftMembershipPermissions(projectId, team),
+                        );
+                    }
+
+                }
+                return Promise.all(permissionPromises);
+            },
+        ).then(() => {
+            return ctx.messageClient.addressChannels("New user permissions successfully added to associated projects.", team.slackIdentity.teamChannel);
+        });
+    }
+}

--- a/src/gluon/team/MembersAddedToTeam.ts
+++ b/src/gluon/team/MembersAddedToTeam.ts
@@ -44,30 +44,31 @@ export class MembersAddedToTeam implements HandleEvent<any> {
     public handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
         logger.info(`Ingested MembersAddedToTeamEvent event: ${JSON.stringify(event.data)}`);
 
-        const membersAddedToTeamEvent = event.data.membersAddedToTeamEvent[0];
+        const membersAddedToTeamEvent = event.data.MembersAddedToTeamEvent[0];
         const team = membersAddedToTeamEvent.team;
 
         return gluonProjectsWhichBelongToGluonTeam(ctx, team.name).then(projects => {
                 let teamOwnersUsernames: string[] = [];
                 let teamMembersUsernames: string[] = [];
 
-                teamOwnersUsernames = _.union(teamOwnersUsernames, team.owners.map(owner => owner.domainUsername));
-                teamMembersUsernames = _.union(teamMembersUsernames, team.members.map(member => member.domainUsername));
+                teamOwnersUsernames = _.union(teamOwnersUsernames, membersAddedToTeamEvent.owners.map(owner => owner.domainUsername));
+                teamMembersUsernames = _.union(teamMembersUsernames, membersAddedToTeamEvent.members.map(member => member.domainUsername));
                 const bitbucketConfiguration = new BitbucketConfiguration(teamOwnersUsernames, teamMembersUsernames);
 
                 const permissionPromises: Array<Promise<any>> = [];
                 const devopsProject = `${_.kebabCase(team.name).toLowerCase()}-devops`;
-                permissionPromises.push(addOpenshiftMembershipPermissions(devopsProject, team));
+                permissionPromises.push(addOpenshiftMembershipPermissions(devopsProject, membersAddedToTeamEvent));
                 for (const project of projects) {
+                    logger.info(`Configuring permissions for project: ${project}`);
                     // Add to bitbucket
                     permissionPromises.push(
-                        bitbucketConfiguration.configureBitbucketProject(project.key),
+                        bitbucketConfiguration.configureBitbucketProject(project.bitbucketProject.key),
                     );
                     // Add to openshift environments
                     for (const environment of ["dev", "sit", "uat"]) {
                         const projectId = `${_.kebabCase(project.name).toLowerCase()}-${environment}`;
                         permissionPromises.push(
-                            addOpenshiftMembershipPermissions(projectId, team),
+                            addOpenshiftMembershipPermissions(projectId, membersAddedToTeamEvent),
                         );
                     }
 

--- a/src/gluon/team/teamIngester.ts
+++ b/src/gluon/team/teamIngester.ts
@@ -95,7 +95,7 @@ export const MembersAddedToTeamEvent: Ingester = {
                 {
                     name: "team",
                     type: {
-                        kind: "SCALAR",
+                        kind: "OBJECT",
                         name: "GluonTeam",
                     },
                 },
@@ -104,7 +104,7 @@ export const MembersAddedToTeamEvent: Ingester = {
                     type: {
                         kind: "LIST",
                         ofType: {
-                            kind: "SCALAR",
+                            kind: "OBJECT",
                             name: "Member",
                         },
                     },
@@ -114,7 +114,7 @@ export const MembersAddedToTeamEvent: Ingester = {
                     type: {
                         kind: "LIST",
                         ofType: {
-                            kind: "SCALAR",
+                            kind: "OBJECT",
                             name: "Member",
                         },
                     },

--- a/src/gluon/team/teamIngester.ts
+++ b/src/gluon/team/teamIngester.ts
@@ -84,3 +84,42 @@ export const MembershipRequestCreatedEvent: Ingester = {
         },
     ],
 };
+
+export const MembersAddedToTeamEvent: Ingester = {
+    root_type: "MembersAddedToTeamEvent",
+    types: [
+        {
+            kind: "OBJECT",
+            name: "MembersAddedToTeamEvent",
+            fields: [
+                {
+                    name: "team",
+                    type: {
+                        kind: "SCALAR",
+                        name: "GluonTeam",
+                    },
+                },
+                {
+                    name: "owners",
+                    type: {
+                        kind: "LIST",
+                        ofType: {
+                            kind: "SCALAR",
+                            name: "Member",
+                        },
+                    },
+                },
+                {
+                    name: "members",
+                    type: {
+                        kind: "LIST",
+                        ofType: {
+                            kind: "SCALAR",
+                            name: "Member",
+                        },
+                    },
+                },
+            ],
+        },
+    ],
+};


### PR DESCRIPTION
Members added after Openshift environments are created or bitbucket projects are linked etc will now automatically be added as users in these associated environments.

Resolves #98 