### PR TITLE
Bitbucket resource paging

### DIFF
--- a/src/gluon/bitbucket/Bitbucket.ts
+++ b/src/gluon/bitbucket/Bitbucket.ts
@@ -47,8 +47,8 @@ export function bitbucketRepositoryForSlug(bitbucketProjectKey: string, slug: st
 export function bitbucketProjects(axiosInstance: AxiosInstance, currentProjects = []): Promise<any> {
     return axiosInstance.get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects?start=${currentProjects.length}`).then(
         projects => {
-            currentProjects.push(projects.data.values);
-            if (projects.data.isLastPage) {
+            currentProjects = currentProjects.concat(projects.data.values);
+            if (projects.data.isLastPage === true) {
                 return Promise.resolve(currentProjects);
             }
 

--- a/src/gluon/bitbucket/Bitbucket.ts
+++ b/src/gluon/bitbucket/Bitbucket.ts
@@ -31,10 +31,7 @@ export function bitbucketProjectFromKey(bitbucketProjectKey: string): Promise<an
 }
 
 export function bitbucketRepositoriesForProjectKey(bitbucketProjectKey: string): Promise<any> {
-    return bitbucketAxios().get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${bitbucketProjectKey}/repos`)
-        .then(repos => {
-            return repos.data;
-        });
+    return getBitbucketResources(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${bitbucketProjectKey}/repos`);
 }
 
 export function bitbucketRepositoryForSlug(bitbucketProjectKey: string, slug: string): Promise<any> {
@@ -42,6 +39,10 @@ export function bitbucketRepositoryForSlug(bitbucketProjectKey: string, slug: st
         .then(repo => {
             return repo.data;
         });
+}
+
+export function bitbucketProjects() {
+    return getBitbucketResources(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects`);
 }
 
 export function getBitbucketResources(resourceUri: string, axiosInstance: AxiosInstance = null, currentResources = []) {

--- a/src/gluon/bitbucket/Bitbucket.ts
+++ b/src/gluon/bitbucket/Bitbucket.ts
@@ -44,15 +44,18 @@ export function bitbucketRepositoryForSlug(bitbucketProjectKey: string, slug: st
         });
 }
 
-export function bitbucketProjects(axiosInstance: AxiosInstance, currentProjects = []): Promise<any> {
-    return axiosInstance.get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects?start=${currentProjects.length}`).then(
-        projects => {
-            currentProjects = currentProjects.concat(projects.data.values);
-            if (projects.data.isLastPage === true) {
-                return Promise.resolve(currentProjects);
+export function getBitbucketResources(resourceUri: string, axiosInstance: AxiosInstance = null, currentResources = []) {
+    if (axiosInstance === null) {
+        axiosInstance = bitbucketAxios();
+    }
+    return axiosInstance.get(`${resourceUri}?start=${currentResources.length}`).then(
+        resources => {
+            currentResources = currentResources.concat(resources.data.values);
+            if (resources.data.isLastPage === true) {
+                return Promise.resolve(currentResources);
             }
 
-            return bitbucketProjects(axiosInstance, currentProjects);
+            return getBitbucketResources(resourceUri, axiosInstance, currentResources);
         },
     );
 }

--- a/src/gluon/bitbucket/Bitbucket.ts
+++ b/src/gluon/bitbucket/Bitbucket.ts
@@ -43,3 +43,16 @@ export function bitbucketRepositoryForSlug(bitbucketProjectKey: string, slug: st
             return repo.data;
         });
 }
+
+export function bitbucketProjects(axiosInstance: AxiosInstance, currentProjects = []): Promise<any> {
+    return axiosInstance.get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects?start=${currentProjects.length}`).then(
+        projects => {
+            currentProjects.push(projects.data.values);
+            if (projects.data.isLastPage) {
+                return Promise.resolve(currentProjects);
+            }
+
+            return bitbucketProjects(axiosInstance, currentProjects);
+        },
+    );
+}

--- a/src/gluon/bitbucket/BitbucketProject.ts
+++ b/src/gluon/bitbucket/BitbucketProject.ts
@@ -17,7 +17,7 @@ import * as _ from "lodash";
 import {QMConfig} from "../../config/QMConfig";
 import {gluonMemberFromScreenName} from "../member/Members";
 import {gluonProjectFromProjectName} from "../project/Projects";
-import {bitbucketAxios, bitbucketProjects} from "./Bitbucket";
+import {bitbucketAxios, getBitbucketResources} from "./Bitbucket";
 
 @CommandHandler("Create a new Bitbucket project", QMConfig.subatomic.commandPrefix + " create bitbucket project")
 export class NewBitbucketProject implements HandleCommand<HandlerResult> {
@@ -89,7 +89,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         if (_.isEmpty(this.bitbucketProjectKey)) {
             // then get a list of projects that the member has access too
-            return bitbucketProjects(bitbucketAxios())
+            return getBitbucketResources(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects`)
                 .then(projects => {
                     logger.info(`Got Bitbucket projects: ${JSON.stringify(projects)}`);
 

--- a/src/gluon/bitbucket/BitbucketProject.ts
+++ b/src/gluon/bitbucket/BitbucketProject.ts
@@ -91,7 +91,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
             // then get a list of projects that the member has access too
             return bitbucketProjects(bitbucketAxios())
                 .then(projects => {
-                    logger.info(`Got Bitbucket projects: ${JSON.stringify(projects.data)}`);
+                    logger.info(`Got Bitbucket projects: ${JSON.stringify(projects)}`);
 
                     const msg: SlackMessage = {
                         text: `Please select the Bitbucket project to link to ${this.projectName}`,
@@ -100,7 +100,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
                             actions: [
                                 menuForCommand({
                                         text: "Select Bitbucket project", options:
-                                            projects.data.values.map(bitbucketProject => {
+                                            projects.map(bitbucketProject => {
                                                 return {
                                                     value: bitbucketProject.key,
                                                     text: bitbucketProject.name,

--- a/src/gluon/bitbucket/BitbucketProject.ts
+++ b/src/gluon/bitbucket/BitbucketProject.ts
@@ -17,7 +17,7 @@ import * as _ from "lodash";
 import {QMConfig} from "../../config/QMConfig";
 import {gluonMemberFromScreenName} from "../member/Members";
 import {gluonProjectFromProjectName} from "../project/Projects";
-import {bitbucketAxios, getBitbucketResources} from "./Bitbucket";
+import {bitbucketAxios, bitbucketProjects} from "./Bitbucket";
 
 @CommandHandler("Create a new Bitbucket project", QMConfig.subatomic.commandPrefix + " create bitbucket project")
 export class NewBitbucketProject implements HandleCommand<HandlerResult> {
@@ -89,7 +89,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         if (_.isEmpty(this.bitbucketProjectKey)) {
             // then get a list of projects that the member has access too
-            return getBitbucketResources(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects`)
+            return bitbucketProjects()
                 .then(projects => {
                     logger.info(`Got Bitbucket projects: ${JSON.stringify(projects)}`);
 

--- a/src/gluon/bitbucket/BitbucketProject.ts
+++ b/src/gluon/bitbucket/BitbucketProject.ts
@@ -17,7 +17,7 @@ import * as _ from "lodash";
 import {QMConfig} from "../../config/QMConfig";
 import {gluonMemberFromScreenName} from "../member/Members";
 import {gluonProjectFromProjectName} from "../project/Projects";
-import {bitbucketAxios} from "./Bitbucket";
+import {bitbucketAxios, bitbucketProjects} from "./Bitbucket";
 
 @CommandHandler("Create a new Bitbucket project", QMConfig.subatomic.commandPrefix + " create bitbucket project")
 export class NewBitbucketProject implements HandleCommand<HandlerResult> {
@@ -89,7 +89,7 @@ export class ListExistingBitbucketProject implements HandleCommand<HandlerResult
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         if (_.isEmpty(this.bitbucketProjectKey)) {
             // then get a list of projects that the member has access too
-            return bitbucketAxios().get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects`)
+            return bitbucketProjects(bitbucketAxios())
                 .then(projects => {
                     logger.info(`Got Bitbucket projects: ${JSON.stringify(projects.data)}`);
 

--- a/src/gluon/packages/CreateApplication.ts
+++ b/src/gluon/packages/CreateApplication.ts
@@ -267,7 +267,7 @@ export class LinkExistingApplication implements HandleCommand<HandlerResult> {
                 } else {
                     return bitbucketRepositoriesForProjectKey(project.bitbucketProject.key)
                         .then(bitbucketRepos => {
-                            logger.debug(`Bitbucket project [${project.bitbucketProject.name}] has repositories: ${JSON.stringify(bitbucketRepos.values)}`);
+                            logger.debug(`Bitbucket project [${project.bitbucketProject.name}] has repositories: ${JSON.stringify(bitbucketRepos)}`);
                             return ctx.messageClient.respond({
                                 text: "Please select the Bitbucket repository which contains the application you want to link",
                                 attachments: [{
@@ -276,7 +276,7 @@ export class LinkExistingApplication implements HandleCommand<HandlerResult> {
                                         menuForCommand({
                                                 text: "Select Bitbucket repository",
                                                 options:
-                                                    bitbucketRepos.values.map(bitbucketRepo => {
+                                                    bitbucketRepos.map(bitbucketRepo => {
                                                         return {
                                                             value: bitbucketRepo.name,
                                                             text: bitbucketRepo.name,

--- a/src/gluon/packages/CreateLibrary.ts
+++ b/src/gluon/packages/CreateLibrary.ts
@@ -196,7 +196,7 @@ export class LinkExistingLibrary implements HandleCommand<HandlerResult> {
                 } else {
                     return bitbucketRepositoriesForProjectKey(project.bitbucketProject.key)
                         .then(bitbucketRepos => {
-                            logger.debug(`Bitbucket project [${project.bitbucketProject.name}] has repositories: ${JSON.stringify(bitbucketRepos.values)}`);
+                            logger.debug(`Bitbucket project [${project.bitbucketProject.name}] has repositories: ${JSON.stringify(bitbucketRepos)}`);
                             return ctx.messageClient.respond({
                                 text: "Please select the Bitbucket repository which contains the library you want to link",
                                 attachments: [{
@@ -205,7 +205,7 @@ export class LinkExistingLibrary implements HandleCommand<HandlerResult> {
                                         menuForCommand({
                                                 text: "Select Bitbucket repository",
                                                 options:
-                                                    bitbucketRepos.values.map(bitbucketRepo => {
+                                                    bitbucketRepos.map(bitbucketRepo => {
                                                         return {
                                                             value: bitbucketRepo.name,
                                                             text: bitbucketRepo.name,


### PR DESCRIPTION
Paged bitbucket resources can now be called so that all resources are return instead of the first page only. The page following call has been generalised and should be used in future for any other such calls too.

Resolves #106 