### PR TITLE
Show Team associated projects

### DIFF
--- a/src/gluon/project/ProjectDetails.ts
+++ b/src/gluon/project/ProjectDetails.ts
@@ -93,7 +93,7 @@ export class ListTeamProjects implements HandleCommand<HandlerResult> {
                         projectBitbucketKey: null,
                     };
 
-                    if (project.hasOwnProperty("bitbucketProject")) {
+                    if (project.bitbucketProject !== null) {
                         parameters.projectBitbucketKey = project.bitbucketProject.key;
                     }
 
@@ -165,7 +165,7 @@ export class ListProjectDetails implements HandleCommand<HandlerResult> {
             const attachments = [];
             for (const application of applications) {
                 let applicationBitbucketUrl = "None";
-                if (application.hasOwnProperty("bitbucketRepository")) {
+                if (application.bitbucketRepository !== null) {
                     applicationBitbucketUrl = application.bitbucketRepository.repoUrl;
                 }
                 attachments.push(
@@ -175,8 +175,17 @@ export class ListProjectDetails implements HandleCommand<HandlerResult> {
                     },
                 );
             }
+
+            let headerMessage = `The current details of the project *${this.projectName}* are are as follows.\n*Description:* ${this.projectDescription}\n*Bitbucket URL:* ${bitbucketURL}\n`;
+
+            if (attachments.length > 0) {
+                headerMessage += "The below applications belong to the project:";
+            } else {
+                headerMessage += "There are no applications that belong to this project yet";
+            }
+
             const msg: SlackMessage = {
-                text: `The current details of the project *${this.projectName}* are are as follows.\n*Description:* ${this.projectDescription}\n*Bitbucket URL:* ${bitbucketURL}\nThe below applications belong to the project:`,
+                text: headerMessage,
                 attachments,
             };
             return ctx.messageClient.respond(msg);


### PR DESCRIPTION
The show projects button now shows the projects associated with the team. The conversation can also be followed to show applications associated to the project as seen below:

<img width="876" alt="screen shot 2018-04-04 at 15 31 18" src="https://user-images.githubusercontent.com/4415392/38352260-e9bb53b4-38b2-11e8-8e09-73e1cd2595c3.png">

If there are no projects associated to the team the following is shown:
<img width="883" alt="screen shot 2018-04-05 at 09 07 21" src="https://user-images.githubusercontent.com/4415392/38352281-f7a2d63c-38b2-11e8-9b3e-8ac97b1f2ab1.png">

With no applications associated to a project:
<img width="888" alt="screen shot 2018-04-05 at 09 23 47" src="https://user-images.githubusercontent.com/4415392/38352317-118c6216-38b3-11e8-8264-028f4d3d023e.png">

Half the commit was committed to master by mistake :(

Resolves #104 

