### PR TITLE
Hide atomist error when error has been handled

### DIFF
--- a/src/gluon/project/ProjectDetails.ts
+++ b/src/gluon/project/ProjectDetails.ts
@@ -120,6 +120,9 @@ export class ListTeamProjects implements HandleCommand<HandlerResult> {
                 };
 
                 return ctx.messageClient.respond(msg);
+            }).catch(() => {
+                // Don't display the error - gluonProjectsWhichBelongToGluonTeam already handles it.
+                return success();
             });
     }
 


### PR DESCRIPTION
Hides the error message when listing projects for a team when the team has no projects associated to it.

Resolves #119 