### PR TITLE
OCP docker repo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here is an example `local.json`:
       "baseUrl": "http://localhost:8080"
     },
     "openshift": {
+      "dockerRepoUrl": "172.30.1.1:5000"
       "masterUrl": "<minishift ip>",
       "auth": {
         "token": "<subatomic service account token>"

--- a/src/config/OpenShiftConfig.ts
+++ b/src/config/OpenShiftConfig.ts
@@ -1,4 +1,5 @@
 export interface OpenShiftConfig {
+    dockerRepoUrl: string;
     masterUrl: string;
     auth: OpenShiftAuth;
 }

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -178,7 +178,7 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                         // If no team email then the address of the createdBy member
                         new SimpleOption("p", "JENKINS_ADMIN_EMAIL=subatomic@local"),
                         // TODO the registry Cluster IP we will have to get by introspecting the registry Service
-                        new SimpleOption("p", `MAVEN_SLAVE_IMAGE=172.30.1.1:5000/${projectId}/jenkins-slave-maven-subatomic:2.0`),
+                        new SimpleOption("p", `MAVEN_SLAVE_IMAGE=${QMConfig.subatomic.openshift.dockerRepoUrl}/${projectId}/jenkins-slave-maven-subatomic:2.0`),
                         new SimpleOption("-namespace", projectId),
                     ],
                 )


### PR DESCRIPTION
Docker repo is now pulled from config. This should be done by introspecting the registry Service at a later date

fixes #124 