### PR TITLE
Slave maven config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here is an example `local.json`:
       "baseUrl": "http://localhost:8080"
     },
     "openshift": {
+      "dockerRepoUrl": "172.30.1.1:5000"
       "masterUrl": "<minishift ip>",
       "auth": {
         "token": "<subatomic service account token>"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "app-root-path": "^2.0.1",
     "axios-https-proxy-fix": "^0.17.1",
     "graphql": "^0.8.2",
+    "promise-retry": "^1.1.1",
     "promise-timeout": "^1.1.1",
     "query-string": "^5.0.1"
   },

--- a/src/config/OpenShiftConfig.ts
+++ b/src/config/OpenShiftConfig.ts
@@ -1,4 +1,5 @@
 export interface OpenShiftConfig {
+    dockerRepoUrl: string;
     masterUrl: string;
     auth: OpenShiftAuth;
 }

--- a/src/gluon/packages/CreateApplication.ts
+++ b/src/gluon/packages/CreateApplication.ts
@@ -342,6 +342,8 @@ node('maven') {
       string(credentialsId: 'dev-project', variable: 'DEV_PROJECT_ID'),
       string(credentialsId: 'sit-project', variable: 'SIT_PROJECT_ID'),
       string(credentialsId: 'uat-project', variable: 'UAT_PROJECT_ID'),
+      string(credentialsId: 'nexus-base-url', variable: 'NEXUS_BASE_URL'),
+      file(credentialsId: 'maven-settings', variable: 'MVN_SETTINGS'),
     ]) {
     teamDevOpsProject = "\${env.DEVOPS_PROJECT_ID}"
     projectDevProject = "\${env.DEV_PROJECT_ID}"
@@ -364,7 +366,11 @@ node('maven') {
     echo "Building application \${app}:\${tag} from commit \${scmVars} with BuildConfig \${appBuildConfig}"
 
     try {
-      sh ': Maven build && ./mvnw --batch-mode test'
+      sh ': Maven build &&' +
+         ' ./mvnw --batch-mode test --settings $MVN_SETTINGS' +
+         ' || mvn --batch-mode test --settings $MVN_SETTINGS' +
+         ' -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn' +
+         ' -Dmaven.test.redirectTestOutputToFile=true'
     } finally {
       junit 'target/surefire-reports/*.xml'
     }

--- a/src/gluon/packages/CreateLibrary.ts
+++ b/src/gluon/packages/CreateLibrary.ts
@@ -257,7 +257,11 @@ node('maven') {
             checkout(scm)
 
             try {
-                sh ': Maven build && ./mvnw --batch-mode verify --settings $MVN_SETTINGS'
+                sh ': Maven build &&' +
+                     ' ./mvnw --batch-mode verify --settings $MVN_SETTINGS' +
+                     ' || mvn --batch-mode verify --settings $MVN_SETTINGS' +
+                     ' -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn' +
+                     ' -Dmaven.test.redirectTestOutputToFile=true'
             } finally {
                 junit 'target/surefire-reports/*.xml'
             }
@@ -271,9 +275,12 @@ node('maven') {
                     repository = 'snapshots'
                 }
 
-                sh ': Maven deploy && ./mvnw --batch-mode deploy -DskipTests ' +
-                        "-DaltDeploymentRepository=nexus::default::\${env.NEXUS_BASE_URL}/\${repository}/ " +
-                        '--settings $MVN_SETTINGS'
+                sh ': Maven deploy &&' +
+                     ' ./mvnw --batch-mode deploy --settings $MVN_SETTINGS -DskipTests' +
+                     ' -DaltDeploymentRepository=nexus::default::\${env.NEXUS_BASE_URL}/\${repository}/' +
+                     ' || mvn --batch-mode deploy --settings $MVN_SETTINGS -DskipTests' +
+                     ' -DaltDeploymentRepository=nexus::default::\${env.NEXUS_BASE_URL}/\${repository}/' +
+                     ' -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
             }
         }
     }

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -269,6 +269,11 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                                         retryFunction();
                                     }
                                 });
+                            }, {
+                                // Retry for up to 3 mins
+                                factor : 1,
+                                retries : 9,
+                                minTimeout : 20000,
                             })
                             .then(() => {
                                 return OCCommon.commonCommand("annotate route",

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -255,8 +255,8 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                             [],
                             [
                                 new SimpleOption("-namespace", projectId),
-                            ], true)
-                            , 60000) // TODO configurable
+                            ], false)
+                            , 180000) // TODO configurable
                             .then(() => {
                                 return OCCommon.commonCommand("annotate route",
                                     "jenkins",
@@ -333,6 +333,8 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                             .catch(err => {
                                 if (err instanceof TimeoutError) {
                                     logger.error(`Waiting for dc/jenkins deployment timed out`);
+                                } else {
+                                    failure(err);
                                 }
                             });
                     })

--- a/src/gluon/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/team/DevOpsEnvironmentRequested.ts
@@ -178,7 +178,7 @@ export class DevOpsEnvironmentRequested implements HandleEvent<any> {
                         // If no team email then the address of the createdBy member
                         new SimpleOption("p", "JENKINS_ADMIN_EMAIL=subatomic@local"),
                         // TODO the registry Cluster IP we will have to get by introspecting the registry Service
-                        new SimpleOption("p", `MAVEN_SLAVE_IMAGE=172.30.1.1:5000/${projectId}/jenkins-slave-maven-subatomic:2.0`),
+                        new SimpleOption("p", `MAVEN_SLAVE_IMAGE=${QMConfig.subatomic.openshift.dockerRepoUrl}/${projectId}/jenkins-slave-maven-subatomic:2.0`),
                         new SimpleOption("-namespace", projectId),
                     ],
                 )

--- a/src/openshift/OCCommon.ts
+++ b/src/openshift/OCCommon.ts
@@ -13,7 +13,11 @@ export class OCCommon {
         const commandCommandInstance = new OCCommand(`${command} ${type}`, parameters,
             options,
         );
-        return commandCommandInstance.execute(useAsync);
+        if (useAsync === true) {
+            return commandCommandInstance.executeAsync();
+        } else {
+            return commandCommandInstance.execute();
+        }
     }
 
     public static createStdIn(type: string, parameters: string[] = [],

--- a/src/openshift/base/OCCommand.ts
+++ b/src/openshift/base/OCCommand.ts
@@ -22,19 +22,14 @@ export class OCCommand implements CommandLineElement {
         return commandString;
     }
 
-    public execute(useAsync = false): Promise<OCCommandResult> {
+    public execute(): Promise<OCCommandResult> {
         const command = this.build();
 
         return new Promise((resolve, reject) => {
-            logger.verbose(`Executing oc command: ${command}`);
+            logger.verbose(`Executing oc command sync: ${command}`);
             try {
-                let execution: any;
-                if (useAsync) {
-                    execution = require("child_process").exec(command);
-                } else {
-                    execution = require("child_process").execSync(command);
-                }
-                // exec(command, (error: any, inherit: string) => {
+                let execution: Buffer;
+                execution = require("child_process").execSync(command);
                 const response = new OCCommandResult();
                 response.command = this.buildDisplayCommand();
                 response.output = execution.toString();
@@ -52,6 +47,34 @@ export class OCCommand implements CommandLineElement {
                 logger.error(`OpenShift client error response: ${JSON.stringify(response)}`);
                 return reject(response);
             }
+        });
+    }
+
+    public executeAsync(): Promise<OCCommandResult> {
+        const command = this.build();
+
+        return new Promise((resolve, reject) => {
+            logger.verbose(`Executing oc command async: ${command}`);
+            require("child-process-promise").exec(command)
+                .then(result => {
+                    const response = new OCCommandResult();
+                    response.command = this.buildDisplayCommand();
+                    response.output = result.stdout;
+                    response.status = true;
+
+                    logger.debug(`OpenShift client response: ${JSON.stringify(response)}`);
+                    return resolve(response);
+                })
+                .catch(error => {
+                    const response = new OCCommandResult();
+                    response.command = this.buildDisplayCommand();
+                    response.code = error.status;
+                    response.status = false;
+                    response.error = error.stderr.toString();
+
+                    logger.error(`OpenShift client error response: ${JSON.stringify(response)}`);
+                    return reject(response);
+                });
         });
     }
 


### PR DESCRIPTION
- The OC rollout status now run async, with retries. This allows the commands after the rollout to succeed without the websocket dying. fixes #100
- changes to the default Jenkinsfile to allow building with mvn without wrapper. This PR contains some of the work to sort out #126
- the `--settings $MVN_SETTINGS` is a temp file and needs to be removed
