### PR TITLE
Http auth setting add

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ Here is an example `local.json`:
   "fingerprints": {
     "data": {
     }
+  },
+  "http": {
+    "enabled": true,
+    "auth": {
+      "basic": {
+        "enabled": true,
+        "username": "user",
+        "password": "password"
+      },
+      "bearer": {
+        "enabled": false
+      }
+    }
   }
 }
 

--- a/config/test.json
+++ b/config/test.json
@@ -1,7 +1,7 @@
 {
   "subatomic": {
-    "commandPrefix" : "sub",
-    "openshift" : {
+    "commandPrefix": "sub",
+    "openshift": {
       "dockerRepoUrl": "123.123.0.0:5000",
       "masterUrl": "https://000.000.00.0:8443",
       "auth": {
@@ -52,7 +52,17 @@
   },
   "fingerprints": {
     "data": {
-
+    }
+  },
+  "http": {
+    "enabled": false,
+    "auth": {
+      "basic": {
+        "enabled": false
+      },
+      "bearer": {
+        "enabled": false
+      }
     }
   }
 }

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -68,6 +68,7 @@ import {
 } from "./gluon/team/TeamSlackChannel";
 
 const token = QMConfig.token;
+const http = QMConfig.http;
 
 export const configuration: any = {
     teamIds: [QMConfig.teamId],
@@ -133,17 +134,7 @@ export const configuration: any = {
         GluonTenantId,
     ],
     token,
-    http: {
-        enabled: true,
-        auth: {
-            basic: {
-                enabled: false,
-            },
-            bearer: {
-                enabled: false,
-            },
-        },
-    },
+    http,
     logging: {
         level: "debug",
         file: false,

--- a/src/config/HttpAuth.ts
+++ b/src/config/HttpAuth.ts
@@ -1,0 +1,4 @@
+export interface HttpAuth {
+    enabled: boolean;
+    auth: any;
+}

--- a/src/config/QMConfig.ts
+++ b/src/config/QMConfig.ts
@@ -1,4 +1,5 @@
 import * as config from "config";
+import {HttpAuth} from "./HttpAuth";
 import {SubatomicConfig} from "./SubatomicConfig";
 
 export class QMConfig {
@@ -8,5 +9,7 @@ export class QMConfig {
     public static teamId: string = config.get("teamId");
 
     public static token: string = config.get("token");
+
+    public static http: HttpAuth = config.get("http");
 
 }

--- a/src/gluon/project/AddConfigServer.ts
+++ b/src/gluon/project/AddConfigServer.ts
@@ -90,7 +90,6 @@ export class AddConfigServer implements HandleCommand<HandlerResult> {
     private addConfigServer(ctx: HandlerContext,
                             gluonTeamName: string,
                             gitUri: string): Promise<any> {
-
         const devOpsProjectId = `${_.kebabCase(gluonTeamName).toLowerCase()}-devops`;
         return OCCommon.commonCommand("create secret generic",
             "subatomic-config-server",

--- a/src/gluon/project/AddConfigServer.ts
+++ b/src/gluon/project/AddConfigServer.ts
@@ -90,6 +90,7 @@ export class AddConfigServer implements HandleCommand<HandlerResult> {
     private addConfigServer(ctx: HandlerContext,
                             gluonTeamName: string,
                             gitUri: string): Promise<any> {
+
         const devOpsProjectId = `${_.kebabCase(gluonTeamName).toLowerCase()}-devops`;
         return OCCommon.commonCommand("create secret generic",
             "subatomic-config-server",


### PR DESCRIPTION
Added the setting configuration allowing us to expose the atomist client commands via http if configured to do so.

Resolves #146 