### PR TITLE
Added the recursive parameter request command type

### DIFF
--- a/src/gluon/shared/RecursiveParameterRequestCommand.ts
+++ b/src/gluon/shared/RecursiveParameterRequestCommand.ts
@@ -1,0 +1,70 @@
+import {
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+} from "@atomist/automation-client";
+import {
+    BaseParameter,
+    declareParameter,
+} from "@atomist/automation-client/internal/metadata/decoratorSupport";
+import _ = require("lodash");
+
+export abstract class RecursiveParameterRequestCommand implements HandleCommand<HandlerResult> {
+
+    private recursiveParameterProperties: string[];
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+
+        if (!this.recursiveParametersAreSet()) {
+            return this.requestUnsetParametersEntry(ctx);
+        }
+
+        return this.runCommand(ctx);
+    }
+
+    public addRecursiveParameterProperty(propertyKey: string) {
+        if (_.isEmpty(this.recursiveParameterProperties)) {
+            this.recursiveParameterProperties = [];
+        }
+        this.recursiveParameterProperties.push(propertyKey);
+    }
+
+    protected abstract requestUnsetParameters(ctx: HandlerContext): Promise<HandlerResult> | void;
+
+    protected abstract runCommand(ctx: HandlerContext): Promise<HandlerResult>;
+
+    private recursiveParametersAreSet(): boolean {
+        let parametersAreSet = true;
+        const dynamicClassInstance: any = this;
+        for (const property of this.recursiveParameterProperties) {
+            if (_.isEmpty(dynamicClassInstance[property])) {
+                parametersAreSet = false;
+                break;
+            }
+        }
+        return parametersAreSet;
+    }
+
+    private requestUnsetParametersEntry(ctx: HandlerContext): Promise<HandlerResult> {
+
+        const result: Promise<HandlerResult> = this.requestUnsetParameters(ctx) || null;
+
+        if (result !== null) {
+            return result;
+        }
+
+        return this.runCommand(ctx);
+    }
+}
+
+export function RecursiveParameter(details: BaseParameter = {}) {
+    return (target: any, propertyKey: string) => {
+        const recursiveParameters: any = {...details};
+        if (target instanceof RecursiveParameterRequestCommand) {
+            recursiveParameters.required = false;
+            recursiveParameters.displayable = false;
+            target.addRecursiveParameterProperty(propertyKey);
+        }
+        declareParameter(target, propertyKey, recursiveParameters);
+    };
+}

--- a/src/gluon/shared/RecursiveParameterRequestCommand.ts
+++ b/src/gluon/shared/RecursiveParameterRequestCommand.ts
@@ -1,7 +1,7 @@
 import {
     HandleCommand,
     HandlerContext,
-    HandlerResult,
+    HandlerResult, logger,
 } from "@atomist/automation-client";
 import {
     BaseParameter,
@@ -38,6 +38,7 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
         const dynamicClassInstance: any = this;
         for (const property of this.recursiveParameterProperties) {
             if (_.isEmpty(dynamicClassInstance[property])) {
+                logger.info(`Recursive parameter ${property} not set.`);
                 parametersAreSet = false;
                 break;
             }
@@ -46,12 +47,14 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
     }
 
     private requestUnsetParametersEntry(ctx: HandlerContext): Promise<HandlerResult> {
-
+        logger.info(`Requesting next unset recursive parameter.`);
         const result: Promise<HandlerResult> = this.requestUnsetParameters(ctx) || null;
 
         if (result !== null) {
             return result;
         }
+
+        logger.info(`Recursive parameter request returned a void result. Assuming all recursive parameters are set.`);
 
         return this.runCommand(ctx);
     }


### PR DESCRIPTION
Formalised the requestUnsetParameter pattern into a class called a RecursiveParameterRequestCommand which eliminates some of the boiler plate that comes with using the pattern and eliminates cases where the pattern can result in dead end paths that terminate commands unexpectedly if used incorrectly.

Resolves #160 