### PR TITLE
Handle QM Error Fix

### DIFF
--- a/src/gluon/shared/Error.ts
+++ b/src/gluon/shared/Error.ts
@@ -17,7 +17,7 @@ export function logErrorAndReturnSuccess(method, error): HandlerResult {
 
 export async function handleQMError(messageClient: QMMessageClient, error) {
     logger.error("Trying to handle QM error.");
-    if ("code" in error && error.code === "ECONNREFUSED") {
+    if (error && "code" in error && error.code === "ECONNREFUSED") {
         logger.error(`Error code suggests and external service is down.\nError: ${util.inspect(error)}`);
         return await messageClient.send(`❗Unexpected failure. An external service dependency appears to be down.`);
     } else if (error instanceof Error) {


### PR DESCRIPTION
Check error is defined before looking for the existence of the code property.

Resolves #211 