### PR TITLE
Selective image stream tagging

### DIFF
--- a/src/gluon/project/ProjectEnvironmentsRequested.ts
+++ b/src/gluon/project/ProjectEnvironmentsRequested.ts
@@ -349,8 +349,8 @@ export class ProjectEnvironmentsRequested implements HandleEvent<any> {
                 ]);
         } catch (error) {
             if (error instanceof OCCommandResult) {
-                const multitenantNetworkPluginMissingError = "error: Managing pod network is only supported for openshift multitenant network plugin";
-                if (!_.isEmpty(error.error) && error.error.indexOf(multitenantNetworkPluginMissingError) > -1) {
+                const multitenantNetworkPluginMissingError = "error: managing pod network is only supported for openshift multitenant network plugin";
+                if (!_.isEmpty(error.error) && error.error.toLowerCase().indexOf(multitenantNetworkPluginMissingError) > -1) {
                     logger.warn("Openshift multitenant network plugin not found. Assuming running on Minishift test environment");
                 } else {
                     throw new OCResultError(error, "Failed to configure multitenant pod network");

--- a/src/gluon/shared/SubatomicOpenshiftQueries.ts
+++ b/src/gluon/shared/SubatomicOpenshiftQueries.ts
@@ -29,6 +29,7 @@ export function subatomicImageStreamTags(namespace: string): Promise<any> {
                 return OCCommon.commonCommand("get", "istag",
                     [],
                     [
+                        new SimpleOption("l", "usage=subatomic-is"),
                         new SimpleOption("-namespace", namespace),
                         new SimpleOption("-output", "json"),
                     ],


### PR DESCRIPTION
Added tagging of only selective image streams using the label usage="subatomic-is".

Added an additional bug fix.

Resolves #203 