### PR TITLE
Fixed broken add members to team functionality.

### DIFF
--- a/src/gluon/commands/team/JoinTeam.ts
+++ b/src/gluon/commands/team/JoinTeam.ts
@@ -142,7 +142,7 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
                 (team: any) => team.slack.teamChannel === this.teamChannel);
 
             if (!_.isEmpty(teamSlackChannel)) {
-                return await this.inviteUserToTeam(ctx, newMember, actioningMember, teamSlackChannel, this.channelId, this.screenName, this.teamId, this.teamChannel, this.slackName);
+                return await this.inviteUserToTeam(ctx, newMember, actioningMember, teamSlackChannel, this.channelId, newMember.slack.userId, this.teamId, this.teamChannel, this.slackName);
             } else {
                 return await this.alertTeamDoesNotExist(ctx);
             }
@@ -203,6 +203,7 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
 
             return await this.welcomeMemberToTeam(ctx, newMember, teamSlackChannel, actioningMember, teamChannel);
         } catch (error) {
+            logger.warn(error);
             return await ctx.messageClient.addressChannels(`User ${slackName} successfully added to your gluon team. Private channels do not currently support automatic user invitation.` +
                 " Please invite the user to this slack channel manually.", teamChannel);
         }

--- a/src/gluon/util/project/ProjectService.ts
+++ b/src/gluon/util/project/ProjectService.ts
@@ -47,11 +47,13 @@ Consider creating a new project called ${projectName}. Click the button below to
             });
     }
 
-    public gluonProjectsWhichBelongToGluonTeam(ctx: HandlerContext, teamName: string): Promise<any[]> {
+    public gluonProjectsWhichBelongToGluonTeam(ctx: HandlerContext, teamName: string, promptToCreateIfNoProjects = true): Promise<any[]> {
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects?teamName=${teamName}`)
             .then(projects => {
                 if (!_.isEmpty(projects.data._embedded)) {
                     return Promise.resolve(projects.data._embedded.projectResources);
+                } else if (!promptToCreateIfNoProjects) {
+                    return Promise.resolve([]);
                 }
 
                 return ctx.messageClient.respond({


### PR DESCRIPTION
Added optional paramater to gluon Projects method allowing user to specify whether we want automatic prompts for project creation. We should probably do this for all these type of functions.

Additionally found another bug related to adding members to a team which was corrected.


Resolves #234 