### PR TITLE
Gluon Logging Update

### DIFF
--- a/src/gluon/commands/bitbucket/BitbucketProject.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProject.ts
@@ -84,7 +84,7 @@ export class NewBitbucketProject extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,
@@ -178,7 +178,7 @@ export class ListExistingBitbucketProject extends RecursiveParameterRequestComma
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/bitbucket/BitbucketProject.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProject.ts
@@ -64,7 +64,7 @@ export class NewBitbucketProject extends RecursiveParameterRequestCommand {
         logger.info(`Team: ${this.teamName}, Project: ${this.projectName}`);
 
         try {
-            const member = await this.memberService.gluonMemberFromScreenName(ctx, this.screenName);
+            const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
 
             const project = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
 
@@ -203,7 +203,7 @@ export class ListExistingBitbucketProject extends RecursiveParameterRequestComma
     private async configBitbucket(ctx: HandlerContext): Promise<HandlerResult> {
         logger.info(`Team: ${this.teamName}, Project: ${this.projectName}`);
 
-        const member = await this.memberService.gluonMemberFromScreenName(ctx, this.screenName);
+        const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
         const gluonProject = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
 
         const projectUiUrl = `${QMConfig.subatomic.bitbucket.baseUrl}/projects/${this.bitbucketProjectKey}`;

--- a/src/gluon/commands/bitbucket/BitbucketProject.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProject.ts
@@ -66,7 +66,7 @@ export class NewBitbucketProject extends RecursiveParameterRequestCommand {
         try {
             const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
 
-            const project = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
+            const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
 
             await this.updateGluonWithBitbucketDetails(project.projectId, this.projectName, project.description, member.memberId);
 
@@ -204,7 +204,7 @@ export class ListExistingBitbucketProject extends RecursiveParameterRequestComma
         logger.info(`Team: ${this.teamName}, Project: ${this.projectName}`);
 
         const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
-        const gluonProject = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
+        const gluonProject = await this.projectService.gluonProjectFromProjectName(this.projectName);
 
         const projectUiUrl = `${QMConfig.subatomic.bitbucket.baseUrl}/projects/${this.bitbucketProjectKey}`;
 

--- a/src/gluon/commands/bitbucket/BitbucketProject.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProject.ts
@@ -8,13 +8,19 @@ import {
     Parameter,
     success,
 } from "@atomist/automation-client";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {BitbucketService} from "../../util/bitbucket/Bitbucket";
 import {MemberService} from "../../util/member/Members";
-import {menuForProjects, ProjectService} from "../../util/project/ProjectService";
-import {handleQMError, QMError, ResponderMessageClient} from "../../util/shared/Error";
+import {
+    menuForProjects,
+    ProjectService,
+} from "../../util/project/ProjectService";
+import {
+    handleQMError,
+    QMError,
+    ResponderMessageClient,
+} from "../../util/shared/Error";
 import {isSuccessCode} from "../../util/shared/Http";
 import {
     RecursiveParameter,
@@ -100,7 +106,7 @@ export class NewBitbucketProject extends RecursiveParameterRequestCommand {
     }
 
     private async updateGluonWithBitbucketDetails(projectId: string, projectName: string, projectDescription: string, memberId: string) {
-        const updateGluonProjectResult = await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
+        const updateGluonProjectResult = await this.projectService.updateProjectWithBitbucketDetails(projectId,
             {
                 bitbucketProject: {
                     name: projectName,
@@ -226,7 +232,7 @@ export class ListExistingBitbucketProject extends RecursiveParameterRequestComma
     }
 
     private async updateGluonProjectWithBitbucketDetails(bitbucketProjectUiUrl: string, createdByMemberId: string, gluonProject, bitbucketProject) {
-        const updateGluonProjectResult = await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${gluonProject.projectId}`,
+        const updateGluonProjectResult = await this.projectService.updateProjectWithBitbucketDetails(gluonProject,
             {
                 bitbucketProject: {
                     bitbucketProjectId: bitbucketProject.id,

--- a/src/gluon/commands/bitbucket/BitbucketProject.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProject.ts
@@ -95,7 +95,7 @@ export class NewBitbucketProject extends RecursiveParameterRequestCommand {
         }
         if (_.isEmpty(this.projectName)) {
             logger.info("Project name is empty");
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return await menuForProjects(
                 ctx,
                 projects,
@@ -189,7 +189,7 @@ export class ListExistingBitbucketProject extends RecursiveParameterRequestComma
         }
         if (_.isEmpty(this.projectName)) {
             logger.info("Project name is empty");
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
 
             return await menuForProjects(
                 ctx,

--- a/src/gluon/commands/jenkins/JenkinsBuild.ts
+++ b/src/gluon/commands/jenkins/JenkinsBuild.ts
@@ -90,7 +90,7 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand {
             }
         }
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return menuForProjects(
                 ctx,
                 projects,

--- a/src/gluon/commands/jenkins/JenkinsBuild.ts
+++ b/src/gluon/commands/jenkins/JenkinsBuild.ts
@@ -98,7 +98,7 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand {
                 "Please select a project which contains the application you would like to build");
         }
         if (_.isEmpty(this.applicationName)) {
-            const applications = await this.applicationService.gluonApplicationsLinkedToGluonProject(ctx, this.projectName);
+            const applications = await this.applicationService.gluonApplicationsLinkedToGluonProject(this.projectName);
             return await menuForApplications(
                 ctx,
                 applications,

--- a/src/gluon/commands/jenkins/JenkinsBuild.ts
+++ b/src/gluon/commands/jenkins/JenkinsBuild.ts
@@ -81,7 +81,7 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/member/Onboard.ts
+++ b/src/gluon/commands/member/Onboard.ts
@@ -11,9 +11,13 @@ import {
 } from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
-import axios from "axios";
 import {QMConfig} from "../../../config/QMConfig";
-import {handleQMError, QMError, ResponderMessageClient} from "../../util/shared/Error";
+import {MemberService} from "../../util/member/Members";
+import {
+    handleQMError,
+    QMError,
+    ResponderMessageClient,
+} from "../../util/shared/Error";
 import {isSuccessCode} from "../../util/shared/Http";
 import {CreateTeam} from "../team/CreateTeam";
 import {JoinTeam} from "../team/JoinTeam";
@@ -51,6 +55,9 @@ export class OnboardMember implements HandleCommand<HandlerResult> {
     })
     public domainUsername: string;
 
+    constructor(private memberService = new MemberService()) {
+    }
+
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             logger.info("Creating");
@@ -74,8 +81,7 @@ export class OnboardMember implements HandleCommand<HandlerResult> {
 
     private async createGluonTeamMember(teamMemberDetails: any) {
 
-        const createMemberResult = await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/members`,
-            teamMemberDetails);
+        const createMemberResult = await this.memberService.createGluonMember(teamMemberDetails);
 
         if (!isSuccessCode(createMemberResult.status)) {
             throw new QMError(`Unable to onboard a member with provided details. Details of the user are already in use.`);

--- a/src/gluon/commands/member/Slack.ts
+++ b/src/gluon/commands/member/Slack.ts
@@ -10,6 +10,7 @@ import {
 } from "@atomist/automation-client";
 import axios from "axios";
 import {QMConfig} from "../../../config/QMConfig";
+import {MemberService} from "../../util/member/Members";
 import {isSuccessCode} from "../../util/shared/Http";
 
 @CommandHandler("Add Slack details to an existing team member", QMConfig.subatomic.commandPrefix + " add slack")
@@ -26,6 +27,9 @@ export class AddSlackDetails implements HandleCommand<HandlerResult> {
         pattern: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
     })
     public email: string;
+
+    constructor(private memberService = new MemberService()) {
+    }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         logger.info(`Adding Slack details for member: ${this.email}`);
@@ -57,8 +61,7 @@ export class AddSlackDetails implements HandleCommand<HandlerResult> {
     }
 
     private async updateGluonMemberSlackDetails(slackScreenName: string, slackUserId: string, gluonMemberId: string) {
-        return await axios.put(
-            `${QMConfig.subatomic.gluon.baseUrl}/members/${gluonMemberId}`,
+        return await this.memberService.updateMemberSlackDetails(gluonMemberId,
             {
                 slack: {
                     screenName: slackScreenName,

--- a/src/gluon/commands/member/Slack.ts
+++ b/src/gluon/commands/member/Slack.ts
@@ -8,7 +8,6 @@ import {
     MappedParameters,
     Parameter,
 } from "@atomist/automation-client";
-import axios from "axios";
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
 import {isSuccessCode} from "../../util/shared/Http";
@@ -57,7 +56,7 @@ export class AddSlackDetails implements HandleCommand<HandlerResult> {
     }
 
     private async findGluonMemberByEmail(emailAddress: string) {
-        return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?email=${emailAddress}`);
+        return await this.memberService.gluonMemberFromEmailAddress(emailAddress);
     }
 
     private async updateGluonMemberSlackDetails(slackScreenName: string, slackUserId: string, gluonMemberId: string) {

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -233,7 +233,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
 
         }
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return await menuForProjects(ctx, projects, this, "Please select the owning project of the package you wish to configure");
         }
         if (_.isEmpty(this.applicationName)) {

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -223,7 +223,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -31,7 +31,6 @@ import {
 } from "../../util/project/ProjectService";
 import {
     handleQMError,
-    logErrorAndReturnSuccess,
     QMError,
     ResponderMessageClient,
 } from "../../util/shared/Error";
@@ -263,7 +262,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
     private async requestJenkinsFileParameter(ctx: HandlerContext): Promise<HandlerResult> {
 
         const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
-        const application = await this.applicationService.gluonApplicationForNameAndProjectName(ctx, this.applicationName, this.projectName);
+        const application = await this.applicationService.gluonApplicationForNameAndProjectName(this.applicationName, this.projectName);
         const username = QMConfig.subatomic.bitbucket.auth.username;
         const password = QMConfig.subatomic.bitbucket.auth.password;
         const gitProject: GitProject = await GitCommandGitProject.cloned({
@@ -321,12 +320,8 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
     private async configurePackage(ctx: HandlerContext): Promise<HandlerResult> {
         const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
 
-        let application;
-        try {
-            application = await this.applicationService.gluonApplicationForNameAndProjectName(ctx, this.applicationName, this.projectName);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.applicationService.gluonApplicationForNameAndProjectName.name, error);
-        }
+        const application = await this.applicationService.gluonApplicationForNameAndProjectName(this.applicationName, this.projectName);
+
         return await this.doConfiguration(
             ctx,
             project.name,

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -237,7 +237,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
             return await menuForProjects(ctx, projects, this, "Please select the owning project of the package you wish to configure");
         }
         if (_.isEmpty(this.applicationName)) {
-            const applications = await this.applicationService.gluonApplicationsLinkedToGluonProject(ctx, this.projectName);
+            const applications = await this.applicationService.gluonApplicationsLinkedToGluonProject(this.projectName);
             return await menuForApplications(ctx, applications, this, "Please select the package you wish to configure");
         }
         if (_.isEmpty(this.openshiftTemplate)) {

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -262,7 +262,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
 
     private async requestJenkinsFileParameter(ctx: HandlerContext): Promise<HandlerResult> {
 
-        const project = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
+        const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
         const application = await this.applicationService.gluonApplicationForNameAndProjectName(ctx, this.applicationName, this.projectName);
         const username = QMConfig.subatomic.bitbucket.auth.username;
         const password = QMConfig.subatomic.bitbucket.auth.password;
@@ -319,12 +319,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
     }
 
     private async configurePackage(ctx: HandlerContext): Promise<HandlerResult> {
-        let project;
-        try {
-            project = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.projectService.gluonProjectFromProjectName.name, error);
-        }
+        const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
 
         let application;
         try {
@@ -497,7 +492,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand {
 
             await this.createApplicationBuildConfig(bitbucketRepoRemoteUrl, appBuildName, this.baseS2IImage, teamDevOpsProjectId);
 
-            const project = await this.projectService.gluonProjectFromProjectName(ctx, projectName);
+            const project = await this.projectService.gluonProjectFromProjectName(projectName);
             logger.info(`Trying to find tenant: ${project.owningTenant}`);
             const tenant = await this.tenantService.gluonTenantFromTenantId(project.owningTenant);
             logger.info(`Found tenant: ${tenant}`);

--- a/src/gluon/commands/packages/CreateApplication.ts
+++ b/src/gluon/commands/packages/CreateApplication.ts
@@ -8,7 +8,6 @@ import {
     Parameter,
     success,
 } from "@atomist/automation-client";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {
@@ -16,8 +15,14 @@ import {
     menuForBitbucketRepositories,
 } from "../../util/bitbucket/Bitbucket";
 import {MemberService} from "../../util/member/Members";
-import {ApplicationType} from "../../util/packages/Applications";
-import {menuForProjects, ProjectService} from "../../util/project/ProjectService";
+import {
+    ApplicationService,
+    ApplicationType,
+} from "../../util/packages/Applications";
+import {
+    menuForProjects,
+    ProjectService,
+} from "../../util/project/ProjectService";
 import {
     handleQMError,
     logErrorAndReturnSuccess,
@@ -72,7 +77,8 @@ export class CreateApplication extends RecursiveParameterRequestCommand {
 
     constructor(private teamService = new TeamService(),
                 private projectService = new ProjectService(),
-                private memberService = new MemberService()) {
+                private memberService = new MemberService(),
+                private applicationService = new ApplicationService()) {
         super();
     }
 
@@ -125,7 +131,7 @@ export class CreateApplication extends RecursiveParameterRequestCommand {
     }
 
     private async createApplicationInGluon(project, member) {
-        const createApplicationResult = await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/applications`,
+        const createApplicationResult = await this.applicationService.createGluonApplication(
             {
                 name: this.name,
                 description: this.description,
@@ -184,7 +190,8 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
     constructor(private teamService = new TeamService(),
                 private projectService = new ProjectService(),
                 private memberService = new MemberService(),
-                private bitbucketService = new BitbucketService()) {
+                private bitbucketService = new BitbucketService(),
+                private applicationService = new ApplicationService()) {
         super();
     }
 
@@ -298,7 +305,7 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
             return (clone as any).name === "ssh";
         }) as any;
 
-        const createApplicationResult = await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/applications`,
+        const createApplicationResult = await this.applicationService.createGluonApplication(
             {
                 name: libraryName,
                 description: libraryDescription,

--- a/src/gluon/commands/packages/CreateApplication.ts
+++ b/src/gluon/commands/packages/CreateApplication.ts
@@ -115,7 +115,7 @@ export class CreateApplication extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(ctx, teams, this);
             }
         }
@@ -219,7 +219,7 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/packages/CreateApplication.ts
+++ b/src/gluon/commands/packages/CreateApplication.ts
@@ -89,12 +89,7 @@ export class CreateApplication extends RecursiveParameterRequestCommand {
                 text: "🚀 Your new application is being created...",
             });
 
-            let member;
-            try {
-                member = await this.memberService.gluonMemberFromScreenName(ctx, this.screenName);
-            } catch (error) {
-                return await logErrorAndReturnSuccess(this.memberService.gluonMemberFromScreenName.name, error);
-            }
+            const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
 
             let project;
             try {
@@ -271,7 +266,7 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
         const project = await this.projectService.gluonProjectFromProjectName(ctx, gluonProjectName);
         logger.debug(`Linking Bitbucket repository: ${bitbucketRepositorySlug}`);
 
-        return await this.linkBitbucketRepository(ctx,
+        return await this.linkBitbucketRepository(
             slackScreeName,
             applicationName,
             applicationDescription,
@@ -280,8 +275,7 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
             project.projectId);
     }
 
-    private async linkBitbucketRepository(ctx: HandlerContext,
-                                          slackScreeName: string,
+    private async linkBitbucketRepository(slackScreeName: string,
                                           libraryName: string,
                                           libraryDescription: string,
                                           bitbucketRepositorySlug: string,
@@ -295,12 +289,8 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
 
         const repo = repoResult.data;
 
-        let member;
-        try {
-            member = await this.memberService.gluonMemberFromScreenName(ctx, slackScreeName);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.memberService.gluonMemberFromScreenName.name, error);
-        }
+        const member = await this.memberService.gluonMemberFromScreenName(slackScreeName);
+
         const remoteUrl = _.find(repo.links.clone, clone => {
             return (clone as any).name === "ssh";
         }) as any;

--- a/src/gluon/commands/packages/CreateApplication.ts
+++ b/src/gluon/commands/packages/CreateApplication.ts
@@ -115,7 +115,7 @@ export class CreateApplication extends RecursiveParameterRequestCommand {
             }
         }
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return await menuForProjects(ctx, projects, this);
         }
     }
@@ -223,7 +223,7 @@ export class LinkExistingApplication extends RecursiveParameterRequestCommand {
             }
         }
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return menuForProjects(
                 ctx,
                 projects,

--- a/src/gluon/commands/packages/CreateLibrary.ts
+++ b/src/gluon/commands/packages/CreateLibrary.ts
@@ -114,7 +114,7 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
             }
         }
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return menuForProjects(
                 ctx,
                 projects,

--- a/src/gluon/commands/packages/CreateLibrary.ts
+++ b/src/gluon/commands/packages/CreateLibrary.ts
@@ -8,7 +8,6 @@ import {
     Parameter,
     success,
 } from "@atomist/automation-client";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {
@@ -16,8 +15,14 @@ import {
     menuForBitbucketRepositories,
 } from "../../util/bitbucket/Bitbucket";
 import {MemberService} from "../../util/member/Members";
-import {ApplicationType} from "../../util/packages/Applications";
-import {menuForProjects, ProjectService} from "../../util/project/ProjectService";
+import {
+    ApplicationService,
+    ApplicationType,
+} from "../../util/packages/Applications";
+import {
+    menuForProjects,
+    ProjectService,
+} from "../../util/project/ProjectService";
 import {
     handleQMError,
     logErrorAndReturnSuccess,
@@ -70,7 +75,8 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
     constructor(private teamService = new TeamService(),
                 private projectService = new ProjectService(),
                 private memberService = new MemberService(),
-                private bitbucketService = new BitbucketService()) {
+                private bitbucketService = new BitbucketService(),
+                private applicationService = new ApplicationService()) {
         super();
     }
 
@@ -181,7 +187,7 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
             return (clone as any).name === "ssh";
         }) as any;
 
-        const createApplicationResult = await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/applications`,
+        const createApplicationResult = await this.applicationService.createGluonApplication(
             {
                 name: libraryName,
                 description: libraryDescription,

--- a/src/gluon/commands/packages/CreateLibrary.ts
+++ b/src/gluon/commands/packages/CreateLibrary.ts
@@ -86,7 +86,6 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
             }, this.teamChannel);
 
             return await this.linkLibraryForGluonProject(
-                ctx,
                 this.screenName,
                 this.name,
                 this.description,
@@ -123,7 +122,7 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
                 "Please select a project to which you would like to link a library to");
         }
         if (_.isEmpty(this.bitbucketRepositorySlug)) {
-            const project = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
+            const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
             if (_.isEmpty(project.bitbucketProject)) {
                 throw new QMError(`The selected project does not have an associated bitbucket project. Please first associate a bitbucket project using the \`${QMConfig.subatomic.commandPrefix} link bitbucket project\` command.`);
             }
@@ -143,13 +142,12 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
         }
     }
 
-    private async linkLibraryForGluonProject(ctx: HandlerContext,
-                                             slackScreeName: string,
+    private async linkLibraryForGluonProject(slackScreeName: string,
                                              libraryName: string,
                                              libraryDescription: string,
                                              bitbucketRepositorySlug: string,
                                              gluonProjectName: string): Promise<HandlerResult> {
-        const project = await this.projectService.gluonProjectFromProjectName(ctx, gluonProjectName);
+        const project = await this.projectService.gluonProjectFromProjectName(gluonProjectName);
         logger.debug(`Linking Bitbucket repository: ${bitbucketRepositorySlug}`);
 
         return await this.linkBitbucketRepository(

--- a/src/gluon/commands/packages/CreateLibrary.ts
+++ b/src/gluon/commands/packages/CreateLibrary.ts
@@ -25,7 +25,6 @@ import {
 } from "../../util/project/ProjectService";
 import {
     handleQMError,
-    logErrorAndReturnSuccess,
     QMError,
     ResponderMessageClient,
 } from "../../util/shared/Error";
@@ -153,7 +152,7 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
         const project = await this.projectService.gluonProjectFromProjectName(ctx, gluonProjectName);
         logger.debug(`Linking Bitbucket repository: ${bitbucketRepositorySlug}`);
 
-        return await this.linkBitbucketRepository(ctx,
+        return await this.linkBitbucketRepository(
             slackScreeName,
             libraryName,
             libraryDescription,
@@ -162,8 +161,7 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
             project.projectId);
     }
 
-    private async linkBitbucketRepository(ctx: HandlerContext,
-                                          slackScreeName: string,
+    private async linkBitbucketRepository(slackScreeName: string,
                                           libraryName: string,
                                           libraryDescription: string,
                                           bitbucketRepositorySlug: string,
@@ -177,12 +175,8 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
 
         const repo = repoResult.data;
 
-        let member;
-        try {
-            member = await this.memberService.gluonMemberFromScreenName(ctx, slackScreeName);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.memberService.gluonMemberFromScreenName.name, error);
-        }
+        const member = await this.memberService.gluonMemberFromScreenName(slackScreeName);
+
         const remoteUrl = _.find(repo.links.clone, clone => {
             return (clone as any).name === "ssh";
         }) as any;

--- a/src/gluon/commands/packages/CreateLibrary.ts
+++ b/src/gluon/commands/packages/CreateLibrary.ts
@@ -105,7 +105,7 @@ export class LinkExistingLibrary extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/project/AddConfigServer.ts
+++ b/src/gluon/commands/project/AddConfigServer.ts
@@ -62,7 +62,7 @@ export class AddConfigServer extends RecursiveParameterRequestCommand {
                 const team = await this.teamService.gluonTeamForSlackTeamChannel(this.teamChannel);
                 this.gluonTeamName = team.name;
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/project/AssociateTeam.ts
+++ b/src/gluon/commands/project/AssociateTeam.ts
@@ -6,7 +6,6 @@ import {
     MappedParameter,
     MappedParameters,
 } from "@atomist/automation-client";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {
@@ -89,7 +88,7 @@ export class AssociateTeam extends RecursiveParameterRequestCommand {
     }
 
     private async linkProjectForTeam(ctx: HandlerContext, teamName: string): Promise<HandlerResult> {
-        const team = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${teamName}`);
+        const team = await this.teamService.gluonTeamByName(teamName);
         const gluonProject = await this.projectService.gluonProjectFromProjectName(this.projectName);
         let updateGluonWithProjectDetails;
         try {
@@ -134,11 +133,7 @@ export class AssociateTeam extends RecursiveParameterRequestCommand {
             allTeams.push(team.name);
         }
 
-        const projectDetails = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects?name=${projectName}`);
-        if (!isSuccessCode(projectDetails.status)) {
-            throw new QMError("Failed to get project details for the project specified.");
-        }
-        const projectTeams = projectDetails.data._embedded.projectResources[0];
+        const projectTeams = await this.projectService.gluonProjectFromProjectName(projectName);
 
         for (const team of projectTeams.teams) {
             associatedTeams.push(team.name);

--- a/src/gluon/commands/project/AssociateTeam.ts
+++ b/src/gluon/commands/project/AssociateTeam.ts
@@ -72,7 +72,7 @@ export class AssociateTeam extends RecursiveParameterRequestCommand {
             );
         }
         if (_.isEmpty(this.teamName)) {
-            const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+            const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
             const availTeams = await this.availableTeamsToAssociate(teams, this.projectName);
 
             if (_.isEmpty(availTeams)) {

--- a/src/gluon/commands/project/AssociateTeam.ts
+++ b/src/gluon/commands/project/AssociateTeam.ts
@@ -90,7 +90,7 @@ export class AssociateTeam extends RecursiveParameterRequestCommand {
 
     private async linkProjectForTeam(ctx: HandlerContext, teamName: string): Promise<HandlerResult> {
         const team = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${teamName}`);
-        const gluonProject = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
+        const gluonProject = await this.projectService.gluonProjectFromProjectName(this.projectName);
         let updateGluonWithProjectDetails;
         try {
             updateGluonWithProjectDetails = await this.updateGluonProject(gluonProject.projectId, gluonProject.createdBy, team.data._embedded.teamResources[0].teamId, team.data._embedded.teamResources[0].name);

--- a/src/gluon/commands/project/AssociateTeam.ts
+++ b/src/gluon/commands/project/AssociateTeam.ts
@@ -9,8 +9,15 @@ import {
 import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
-import {menuForProjects, ProjectService} from "../../util/project/ProjectService";
-import {handleQMError, QMError, ResponderMessageClient} from "../../util/shared/Error";
+import {
+    menuForProjects,
+    ProjectService,
+} from "../../util/project/ProjectService";
+import {
+    handleQMError,
+    QMError,
+    ResponderMessageClient,
+} from "../../util/shared/Error";
 import {isSuccessCode} from "../../util/shared/Http";
 import {
     RecursiveParameter,
@@ -101,7 +108,8 @@ export class AssociateTeam extends RecursiveParameterRequestCommand {
     }
 
     private async updateGluonProject(projectId: string, createdBy: string, teamId: string, name: string) {
-        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
+
+        return await this.projectService.associateTeamToProject(projectId,
             {
                 productId: `${projectId}`,
                 createdBy: `${createdBy}`,

--- a/src/gluon/commands/project/AssociateTeam.ts
+++ b/src/gluon/commands/project/AssociateTeam.ts
@@ -63,7 +63,7 @@ export class AssociateTeam extends RecursiveParameterRequestCommand {
 
     protected async setNextParameter(ctx: HandlerContext): Promise<HandlerResult> {
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectList(ctx);
+            const projects = await this.projectService.gluonProjectList();
             return await menuForProjects(
                 ctx,
                 projects,

--- a/src/gluon/commands/project/CreateOpenShiftPvc.ts
+++ b/src/gluon/commands/project/CreateOpenShiftPvc.ts
@@ -16,7 +16,6 @@ import {OCService} from "../../util/openshift/OCService";
 import {ProjectService} from "../../util/project/ProjectService";
 import {
     handleQMError,
-    logErrorAndReturnSuccess,
     ResponderMessageClient,
 } from "../../util/shared/Error";
 import {
@@ -157,36 +156,32 @@ Now that your PVCs have been created, you can add this PVC as storage to an appl
     }
 
     private async presentMenuToSelectProjectToCreatePvcFor(ctx: HandlerContext): Promise<HandlerResult> {
-        try {
-            const teams = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.gluonTeamName);
+        const teams = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.gluonTeamName);
 
-            const msg: SlackMessage = {
-                text: "Please select the project, whose OpenShift environments the PVCs will be created in",
-                attachments: [{
-                    fallback: "Please select a project",
-                    actions: [
-                        menuForCommand({
-                                text: "Select Project", options:
-                                    teams.map(project => {
-                                        return {
-                                            value: project.name,
-                                            text: project.name,
-                                        };
-                                    }),
-                            },
-                            this, "gluonProjectName",
-                            {
-                                gluonTeamName: this.gluonTeamName,
-                                pvcName: this.pvcName,
-                            }),
-                    ],
-                }],
-            };
+        const msg: SlackMessage = {
+            text: "Please select the project, whose OpenShift environments the PVCs will be created in",
+            attachments: [{
+                fallback: "Please select a project",
+                actions: [
+                    menuForCommand({
+                            text: "Select Project", options:
+                                teams.map(project => {
+                                    return {
+                                        value: project.name,
+                                        text: project.name,
+                                    };
+                                }),
+                        },
+                        this, "gluonProjectName",
+                        {
+                            gluonTeamName: this.gluonTeamName,
+                            pvcName: this.pvcName,
+                        }),
+                ],
+            }],
+        };
 
-            return await ctx.messageClient.respond(msg);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.projectService.gluonProjectsWhichBelongToGluonTeam.name, error);
-        }
+        return await ctx.messageClient.respond(msg);
     }
 
     private async presentMenuToSelectOpenshiftProjectToCreatePvcIn(ctx: HandlerContext, projectId: string) {

--- a/src/gluon/commands/project/CreateOpenShiftPvc.ts
+++ b/src/gluon/commands/project/CreateOpenShiftPvc.ts
@@ -131,32 +131,29 @@ Now that your PVCs have been created, you can add this PVC as storage to an appl
     }
 
     private async presentMenuToSelectProjectAssociatedTeam(ctx: HandlerContext): Promise<HandlerResult> {
-        try {
-            const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
-            const msg: SlackMessage = {
-                text: "Please select a team associated with the project you wish to create a PVC for",
-                attachments: [{
-                    fallback: "Please select a team",
-                    actions: [
-                        menuForCommand({
-                                text: "Select Team", options:
-                                    teams.map(team => {
-                                        return {
-                                            value: team.name,
-                                            text: team.name,
-                                        };
-                                    }),
-                            },
-                            this, "gluonTeamName",
-                            {pvcName: this.pvcName}),
-                    ],
-                }],
-            };
 
-            return await ctx.messageClient.respond(msg);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo.name, error);
-        }
+        const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
+        const msg: SlackMessage = {
+            text: "Please select a team associated with the project you wish to create a PVC for",
+            attachments: [{
+                fallback: "Please select a team",
+                actions: [
+                    menuForCommand({
+                            text: "Select Team", options:
+                                teams.map(team => {
+                                    return {
+                                        value: team.name,
+                                        text: team.name,
+                                    };
+                                }),
+                        },
+                        this, "gluonTeamName",
+                        {pvcName: this.pvcName}),
+                ],
+            }],
+        };
+
+        return await ctx.messageClient.respond(msg);
     }
 
     private async presentMenuToSelectProjectToCreatePvcFor(ctx: HandlerContext): Promise<HandlerResult> {

--- a/src/gluon/commands/project/CreateProject.ts
+++ b/src/gluon/commands/project/CreateProject.ts
@@ -7,7 +7,6 @@ import {
     MappedParameters,
     Parameter,
 } from "@atomist/automation-client";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
@@ -118,7 +117,7 @@ export class CreateProject extends RecursiveParameterRequestCommand {
     }
 
     private async getGluonTeamFromName(teamName: string) {
-        const teamQueryResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${teamName}`);
+        const teamQueryResult = await this.teamService.gluonTeamByName(teamName);
         if (!isSuccessCode(teamQueryResult.status)) {
             logger.error(`Failed to find team ${teamName}. Error: ${JSON.stringify(teamQueryResult)}`);
             throw new QMError(`Team ${teamName} does not appear to be a valid SubAtomic team.`);

--- a/src/gluon/commands/project/CreateProject.ts
+++ b/src/gluon/commands/project/CreateProject.ts
@@ -77,7 +77,7 @@ export class CreateProject extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/project/CreateProject.ts
+++ b/src/gluon/commands/project/CreateProject.ts
@@ -11,6 +11,7 @@ import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
+import {ProjectService} from "../../util/project/ProjectService";
 import {
     handleQMError,
     logErrorAndReturnSuccess,
@@ -56,7 +57,8 @@ export class CreateProject extends RecursiveParameterRequestCommand {
 
     constructor(private teamService = new TeamService(),
                 private tenantService = new TenantService(),
-                private memberService = new MemberService()) {
+                private memberService = new MemberService(),
+                private projectService = new ProjectService()) {
         super();
     }
 
@@ -130,7 +132,7 @@ export class CreateProject extends RecursiveParameterRequestCommand {
     }
 
     private async createGluonProject(projectDetails) {
-        const projectCreationResult = await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/projects`,
+        const projectCreationResult = await this.projectService.createGluonProject(
             projectDetails);
         if (projectCreationResult.status === 409) {
             logger.error(`Failed to create project since the project name is already in use.`);

--- a/src/gluon/commands/project/CreateProject.ts
+++ b/src/gluon/commands/project/CreateProject.ts
@@ -14,7 +14,6 @@ import {MemberService} from "../../util/member/Members";
 import {ProjectService} from "../../util/project/ProjectService";
 import {
     handleQMError,
-    logErrorAndReturnSuccess,
     QMError,
     ResponderMessageClient,
 } from "../../util/shared/Error";
@@ -99,12 +98,8 @@ export class CreateProject extends RecursiveParameterRequestCommand {
 
     private async requestNewProjectForTeamAndTenant(ctx: HandlerContext, screenName: string,
                                                     teamName: string, tenantId: string): Promise<any> {
-        let member;
-        try {
-            member = await this.memberService.gluonMemberFromScreenName(ctx, screenName);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.memberService.gluonMemberFromScreenName.name, error);
-        }
+
+        const member = await this.memberService.gluonMemberFromScreenName(screenName);
 
         const team = await this.getGluonTeamFromName(teamName);
 

--- a/src/gluon/commands/project/ProjectDetails.ts
+++ b/src/gluon/commands/project/ProjectDetails.ts
@@ -70,12 +70,8 @@ export class ListTeamProjects extends RecursiveParameterRequestCommand {
     }
 
     private async listTeamProjects(ctx: HandlerContext, teamName: string): Promise<HandlerResult> {
-        let projects;
-        try {
-            projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, teamName);
-        } catch (error) {
-            return await logErrorAndReturnSuccess(this.projectService.gluonProjectsWhichBelongToGluonTeam.name, error);
-        }
+        const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(teamName);
+
         const attachments = [];
 
         for (const project of projects) {

--- a/src/gluon/commands/project/ProjectDetails.ts
+++ b/src/gluon/commands/project/ProjectDetails.ts
@@ -58,7 +58,7 @@ export class ListTeamProjects extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/project/ProjectEnvironments.ts
+++ b/src/gluon/commands/project/ProjectEnvironments.ts
@@ -93,7 +93,7 @@ export class NewProjectEnvironments extends RecursiveParameterRequestCommand {
             }
         }
         if (_.isEmpty(this.projectName)) {
-            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, this.teamName);
+            const projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(this.teamName);
             return await menuForProjects(
                 ctx,
                 projects,

--- a/src/gluon/commands/project/ProjectEnvironments.ts
+++ b/src/gluon/commands/project/ProjectEnvironments.ts
@@ -65,12 +65,7 @@ export class NewProjectEnvironments extends RecursiveParameterRequestCommand {
                 text: `Requesting project environment's for project *${this.projectName}*`,
             }, this.teamChannel);
 
-            let member;
-            try {
-                member = await this.memberService.gluonMemberFromScreenName(ctx, this.screenName);
-            } catch (error) {
-                return await logErrorAndReturnSuccess(this.memberService.gluonMemberFromScreenName.name, error);
-            }
+            const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
 
             let project;
             try {

--- a/src/gluon/commands/project/ProjectEnvironments.ts
+++ b/src/gluon/commands/project/ProjectEnvironments.ts
@@ -9,11 +9,13 @@ import {
     success,
     Tags,
 } from "@atomist/automation-client";
-import axios from "axios";
 import _ = require("lodash");
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
-import {menuForProjects, ProjectService} from "../../util/project/ProjectService";
+import {
+    menuForProjects,
+    ProjectService,
+} from "../../util/project/ProjectService";
 import {
     handleQMError,
     logErrorAndReturnSuccess,
@@ -113,12 +115,9 @@ export class NewProjectEnvironments extends RecursiveParameterRequestCommand {
     }
 
     private async requestProjectEnvironment(projectId: string, memberId: string) {
-        const projectEnvironmentRequestResult = await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
-            {
-                projectEnvironment: {
-                    requestedBy: memberId,
-                },
-            });
+        const projectEnvironmentRequestResult = await this.projectService.requestProjectEnvironment(projectId,
+            memberId,
+        );
 
         if (!isSuccessCode(projectEnvironmentRequestResult.status)) {
             logger.error(`Failed to request project environment for project ${this.projectName}. Error: ${JSON.stringify(projectEnvironmentRequestResult)}`);

--- a/src/gluon/commands/project/ProjectEnvironments.ts
+++ b/src/gluon/commands/project/ProjectEnvironments.ts
@@ -89,7 +89,7 @@ export class NewProjectEnvironments extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (error) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/project/ProjectEnvironments.ts
+++ b/src/gluon/commands/project/ProjectEnvironments.ts
@@ -18,7 +18,6 @@ import {
 } from "../../util/project/ProjectService";
 import {
     handleQMError,
-    logErrorAndReturnSuccess,
     QMError,
     ResponderMessageClient,
 } from "../../util/shared/Error";
@@ -67,12 +66,7 @@ export class NewProjectEnvironments extends RecursiveParameterRequestCommand {
 
             const member = await this.memberService.gluonMemberFromScreenName(this.screenName);
 
-            let project;
-            try {
-                project = await this.projectService.gluonProjectFromProjectName(ctx, this.projectName);
-            } catch (error) {
-                return await logErrorAndReturnSuccess(this.projectService.gluonProjectFromProjectName.name, error);
-            }
+            const project = await this.projectService.gluonProjectFromProjectName(this.projectName);
 
             await this.requestProjectEnvironment(project.projectId, member.memberId);
 

--- a/src/gluon/commands/team/DevOpsEnvironment.ts
+++ b/src/gluon/commands/team/DevOpsEnvironment.ts
@@ -55,7 +55,7 @@ export class NewDevOpsEnvironment extends RecursiveParameterRequestCommand {
                 this.teamName = team.name;
                 return await this.handle(ctx);
             } catch (slackChannelError) {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.screenName);
+                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.screenName);
                 return await menuForTeams(
                     ctx,
                     teams,

--- a/src/gluon/commands/team/DevOpsEnvironment.ts
+++ b/src/gluon/commands/team/DevOpsEnvironment.ts
@@ -12,7 +12,6 @@ import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
-import {logErrorAndReturnSuccess} from "../../util/shared/Error";
 import {isSuccessCode} from "../../util/shared/Http";
 import {
     RecursiveParameter,
@@ -74,12 +73,7 @@ export class NewDevOpsEnvironment extends RecursiveParameterRequestCommand {
             text: `Requesting DevOps environment for *${teamName}* team.`,
         }, teamChannel);
 
-        let member;
-        try {
-            member = await this.memberService.gluonMemberFromScreenName(ctx, screenName);
-        } catch (error) {
-            return logErrorAndReturnSuccess(this.memberService.gluonMemberFromScreenName.name, error);
-        }
+        const member = await this.memberService.gluonMemberFromScreenName(screenName);
 
         const teamQueryResult = await this.getGluonTeamFromTeamName(teamName);
 

--- a/src/gluon/commands/team/DevOpsEnvironment.ts
+++ b/src/gluon/commands/team/DevOpsEnvironment.ts
@@ -106,12 +106,7 @@ export class NewDevOpsEnvironment extends RecursiveParameterRequestCommand {
     }
 
     private async requestDevOpsEnvironmentThroughGluon(teamId: string, memberId: string) {
-        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
-            {
-                devOpsEnvironment: {
-                    requestedBy: memberId,
-                },
-            });
+        return await this.teamService.requestDevOpsEnvironment(teamId, memberId);
     }
 
 }

--- a/src/gluon/commands/team/DevOpsEnvironment.ts
+++ b/src/gluon/commands/team/DevOpsEnvironment.ts
@@ -8,7 +8,6 @@ import {
     success,
     Tags,
 } from "@atomist/automation-client";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
@@ -96,7 +95,7 @@ export class NewDevOpsEnvironment extends RecursiveParameterRequestCommand {
     }
 
     private async getGluonTeamFromTeamName(teamName: string) {
-        return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${teamName}`);
+        return await this.teamService.gluonTeamByName(teamName);
     }
 
     private async requestDevOpsEnvironmentThroughGluon(teamId: string, memberId: string) {

--- a/src/gluon/commands/team/JoinTeam.ts
+++ b/src/gluon/commands/team/JoinTeam.ts
@@ -175,9 +175,12 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
 
     private async inviteUserToTeam(ctx: HandlerContext, newMember, actioningMember, teamSlackChannel, channelId, screenName, teamId, teamChannel, slackName) {
         const newMemberId = newMember.memberId;
-        logger.info(`Adding member [${newMemberId}] to team with ${JSON.stringify(teamSlackChannel._links.self.href)}`);
+        logger.info(`Adding member [${newMemberId}] to team ${JSON.stringify(teamSlackChannel._links.self.href)}`);
 
-        const updateTeamResult = await this.teamService.addMemberToTeam(teamSlackChannel.teamId,
+        const splitLink = teamSlackChannel._links.self.href.split("/");
+        const gluonTeamId = splitLink[splitLink.length - 1];
+
+        const updateTeamResult = await this.teamService.addMemberToTeam(gluonTeamId,
             {
                 members: [{
                     memberId: newMemberId,

--- a/src/gluon/commands/team/JoinTeam.ts
+++ b/src/gluon/commands/team/JoinTeam.ts
@@ -15,10 +15,10 @@ import {
 } from "@atomist/automation-client/spi/message/MessageClient";
 import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/handlers/command/slack/AssociateRepo";
 import {SlackMessage, url} from "@atomist/slack-messages";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import * as graphql from "../../../typings/types";
+import {MemberService} from "../../util/member/Members";
 import {
     handleQMError,
     QMError,
@@ -36,9 +36,12 @@ export class JoinTeam implements HandleCommand<HandlerResult> {
     @MappedParameter(MappedParameters.SlackUser)
     public slackName: string;
 
+    constructor(private teamService = new TeamService()) {
+    }
+
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
-            const teamsQueryResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams`);
+            const teamsQueryResult = await this.teamService.getAllTeams();
 
             if (!isSuccessCode(teamsQueryResult.status)) {
                 return this.alertUserThatNoTeamsExist(ctx);
@@ -123,7 +126,7 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
     })
     public slackName: string;
 
-    constructor(private teamService = new TeamService()) {
+    constructor(private teamService = new TeamService(), private memberService = new MemberService()) {
     }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
@@ -136,13 +139,13 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
 
             logger.info(`Got ChatId: ${chatId}`);
 
-            const newMember = await this.getNewMember(ctx, chatId);
+            const newMember = await this.getNewMember(chatId);
 
             logger.info(`Gluon member found: ${JSON.stringify(newMember)}`);
 
             logger.info(`Getting teams that ${this.screenName} (you) are a part of...`);
 
-            const actioningMember = await this.getGluonMemberFromScreenName(this.screenName);
+            const actioningMember = await this.memberService.gluonMemberFromScreenName(this.screenName);
 
             logger.info(`Got member's teams you belong to: ${JSON.stringify(actioningMember)}`);
 
@@ -159,14 +162,8 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
         }
     }
 
-    private async getNewMember(ctx: HandlerContext, chatId: string) {
-        const newMemberQueryResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${chatId}`);
-
-        if (!isSuccessCode(newMemberQueryResult.status)) {
-            return await alertGluonMemberForSlackMentionDoesNotExist(ctx, this.slackName, this.docs("onboard-me"));
-        }
-
-        const newMember = newMemberQueryResult.data._embedded.teamMemberResources[0];
+    private async getNewMember(chatId: string) {
+        const newMember = await this.memberService.gluonMemberFromScreenName(chatId);
 
         if (!_.isEmpty(_.find(newMember.teams,
             (team: any) => team.slack.teamChannel === this.teamChannel))) {
@@ -174,15 +171,6 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
         }
 
         return newMember;
-    }
-
-    private async getGluonMemberFromScreenName(screenName: string) {
-        const memberResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${screenName}`);
-        if (!isSuccessCode(memberResult.status)) {
-            throw new QMError(`${this.screenName} does not appear to have been onboarded onto the Subatomic system`);
-        }
-
-        return memberResult.data._embedded.teamMemberResources[0];
     }
 
     private async inviteUserToTeam(ctx: HandlerContext, newMember, actioningMember, teamSlackChannel, channelId, screenName, teamId, teamChannel, slackName) {
@@ -279,7 +267,8 @@ export class CreateMembershipRequestToTeam implements HandleCommand<HandlerResul
     })
     public slackName: string;
 
-    constructor(private teamService = new TeamService()) {
+    constructor(private teamService = new TeamService(),
+                private memberService = new MemberService()) {
     }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
@@ -290,7 +279,7 @@ export class CreateMembershipRequestToTeam implements HandleCommand<HandlerResul
 
             const chatId = await loadScreenNameByUserId(ctx, screenName);
 
-            const newMemberQueryResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${chatId}`);
+            const newMemberQueryResult = await this.memberService.gluonMemberFromScreenName(chatId);
 
             if (!isSuccessCode(newMemberQueryResult.status)) {
                 return await alertGluonMemberForSlackMentionDoesNotExist(ctx, this.slackName, this.docs("onboard-me"));

--- a/src/gluon/commands/team/TeamSlackChannel.ts
+++ b/src/gluon/commands/team/TeamSlackChannel.ts
@@ -15,9 +15,9 @@ import {addBotToSlackChannel} from "@atomist/lifecycle-automation/handlers/comma
 import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/handlers/command/slack/AssociateRepo";
 import {createChannel} from "@atomist/lifecycle-automation/handlers/command/slack/CreateChannel";
 import {SlackMessage, url} from "@atomist/slack-messages";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
+import {MemberService} from "../../util/member/Members";
 import {
     handleQMError,
     QMError,
@@ -104,13 +104,13 @@ export class NewTeamSlackChannel implements HandleCommand {
     })
     public teamChannel: string;
 
-    constructor(private teamService = new TeamService()) {
+    constructor(private teamService = new TeamService(), private teamSlackChannelService = new TeamSlackChannelService()) {
     }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             this.teamChannel = _.isEmpty(this.teamChannel) ? this.teamName : this.teamChannel;
-            return await linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.teamChannel, this.docs(), true, this.teamService);
+            return await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.teamChannel, this.docs(), true);
         } catch (error) {
             return await this.handleError(ctx, error);
         }
@@ -148,12 +148,13 @@ export class LinkExistingTeamSlackChannel extends RecursiveParameterRequestComma
     })
     public teamChannel: string;
 
-    constructor(private teamService = new TeamService()) {
+    constructor(private teamService = new TeamService(),
+                private teamSlackChannelService = new TeamSlackChannelService()) {
         super();
     }
 
     protected async runCommand(ctx: HandlerContext) {
-        return await linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.teamChannel, this.docs(), false, this.teamService);
+        return await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.teamChannel, this.docs(), false);
     }
 
     protected async setNextParameter(ctx: HandlerContext): Promise<HandlerResult> {
@@ -173,113 +174,119 @@ export class LinkExistingTeamSlackChannel extends RecursiveParameterRequestComma
     }
 }
 
-async function linkSlackChannelToGluonTeam(ctx: HandlerContext,
-                                           gluonTeamName: string,
-                                           slackTeamId: string,
-                                           slackChannelName: string,
-                                           documentationLink: string,
-                                           isNewChannel: boolean,
-                                           teamService: TeamService): Promise<HandlerResult> {
-    let finalisedSlackChannelName: string = slackChannelName;
-    if (isNewChannel) {
-        finalisedSlackChannelName = _.kebabCase(slackChannelName);
+export class TeamSlackChannelService {
+
+    constructor(private teamService = new TeamService(), private memberService = new MemberService()) {
     }
 
-    const teamQueryResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${gluonTeamName}`);
-
-    if (isSuccessCode(teamQueryResult.status)) {
-        const team = teamQueryResult.data._embedded.teamResources[0];
-
-        logger.info(`Updating team channel [${finalisedSlackChannelName}]: ${team.teamId}`);
-
-        await teamService.addSlackDetailsToTeam(team.teamId, {
-            slack: {
-                teamChannel: finalisedSlackChannelName,
-            },
-        });
-
-        await createTeamSlackChannel(ctx, slackTeamId, slackChannelName, team);
-    } else {
-        return await requestNonExistentTeamsCreation(ctx, gluonTeamName, documentationLink);
-    }
-}
-
-async function createTeamSlackChannel(ctx: HandlerContext, slackTeamId: string, slackChannelName: string, team): Promise<HandlerResult> {
-    try {
-        const channel = await createChannel(ctx, slackTeamId, slackChannelName);
-        if (channel && channel.createSlackChannel) {
-            await addBotToSlackChannel(ctx, slackTeamId, channel.createSlackChannel.id);
-
-            await inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.members);
-
-            await inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.owners);
-
-            return await success();
-        }
-        // allow error to fall through to final return otherwise
-    } catch (err) {
-        if (err.networkError && err.networkError.response && err.networkError.response.status === 400) {
-            return await ctx.messageClient.respond(`The channel has been successfully linked to your team but since the channel "${slackChannelName}" is private` +
-                ` the atomist bot cannot be automatically invited. Please manually invite the atomist bot using the \`/invite @atomist\` command in the "${slackChannelName}" slack channel.`);
-        }
-        // allow error to fall through to final return otherwise
-    }
-    throw new QMError(`Channel with channel name ${slackChannelName} could not be created.`);
-
-}
-
-async function inviteListOfGluonMembersToChannel(ctx: HandlerContext, slackTeamId: string, channelId: string, slackChannelName: string, memberList): Promise<void> {
-    for (const member of memberList) {
-        try {
-            await tryInviteGluonMemberToChannel(ctx, member.memberId, slackTeamId, channelId);
-        } catch (err) {
-            // Don't outright fail. Just alert the user.
-            await ctx.messageClient.respond(`❗Unable to invite member "${member.firstName} ${member.lastName}" to channel ${slackChannelName}. Failed with error message: ${err.message}`);
-        }
-    }
-}
-
-async function tryInviteGluonMemberToChannel(ctx: HandlerContext,
-                                             gluonMemberId: string,
+    public async linkSlackChannelToGluonTeam(ctx: HandlerContext,
+                                             gluonTeamName: string,
                                              slackTeamId: string,
-                                             slackChannelId: string): Promise<any> {
-    logger.info("Creating promise to find and add member: " + gluonMemberId);
-    const memberQueryResponse = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members/${gluonMemberId}`);
+                                             slackChannelName: string,
+                                             documentationLink: string,
+                                             isNewChannel: boolean): Promise<HandlerResult> {
+        let finalisedSlackChannelName: string = slackChannelName;
+        if (isNewChannel) {
+            finalisedSlackChannelName = _.kebabCase(slackChannelName);
+        }
 
-    if (!isSuccessCode(memberQueryResponse.status)) {
-        throw new Error("Unable to find member");
+        const teamQueryResult = await this.teamService.gluonTeamByName(gluonTeamName);
+
+        if (isSuccessCode(teamQueryResult.status)) {
+            const team = teamQueryResult.data._embedded.teamResources[0];
+
+            logger.info(`Updating team channel [${finalisedSlackChannelName}]: ${team.teamId}`);
+
+            await this.teamService.addSlackDetailsToTeam(team.teamId, {
+                slack: {
+                    teamChannel: finalisedSlackChannelName,
+                },
+            });
+
+            await this.createTeamSlackChannel(ctx, slackTeamId, slackChannelName, team);
+        } else {
+            return await this.requestNonExistentTeamsCreation(ctx, gluonTeamName, documentationLink);
+        }
     }
 
-    const member = memberQueryResponse.data;
-    if (member.slack !== null) {
-        logger.info(`Inviting member: ${member.firstName}`);
-        return await inviteUserToSlackChannel(ctx, slackTeamId, slackChannelId, member.slack.userId);
-    } else {
-        throw new Error("User has no associated slack id to invite");
-    }
-}
+    private async createTeamSlackChannel(ctx: HandlerContext, slackTeamId: string, slackChannelName: string, team): Promise<HandlerResult> {
+        try {
+            const channel = await createChannel(ctx, slackTeamId, slackChannelName);
+            if (channel && channel.createSlackChannel) {
+                await addBotToSlackChannel(ctx, slackTeamId, channel.createSlackChannel.id);
 
-async function requestNonExistentTeamsCreation(ctx: HandlerContext, gluonTeamName: string, documentationLink: string) {
-    const msg: SlackMessage = {
-        text: `There was an error creating your *${gluonTeamName}* team channel`,
-        attachments: [{
-            text: `
+                await this.inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.members);
+
+                await this.inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.owners);
+
+                return await success();
+            }
+            // allow error to fall through to final return otherwise
+        } catch (err) {
+            if (err.networkError && err.networkError.response && err.networkError.response.status === 400) {
+                return await ctx.messageClient.respond(`The channel has been successfully linked to your team but since the channel "${slackChannelName}" is private` +
+                    ` the atomist bot cannot be automatically invited. Please manually invite the atomist bot using the \`/invite @atomist\` command in the "${slackChannelName}" slack channel.`);
+            }
+            // allow error to fall through to final return otherwise
+        }
+        throw new QMError(`Channel with channel name ${slackChannelName} could not be created.`);
+
+    }
+
+    private async inviteListOfGluonMembersToChannel(ctx: HandlerContext, slackTeamId: string, channelId: string, slackChannelName: string, memberList): Promise<void> {
+        for (const member of memberList) {
+            try {
+                await this.tryInviteGluonMemberToChannel(ctx, member.memberId, slackTeamId, channelId);
+            } catch (err) {
+                // Don't outright fail. Just alert the user.
+                await ctx.messageClient.respond(`❗Unable to invite member "${member.firstName} ${member.lastName}" to channel ${slackChannelName}. Failed with error message: ${err.message}`);
+            }
+        }
+    }
+
+    private async tryInviteGluonMemberToChannel(ctx: HandlerContext,
+                                                gluonMemberId: string,
+                                                slackTeamId: string,
+                                                slackChannelId: string): Promise<any> {
+        logger.info("Creating promise to find and add member: " + gluonMemberId);
+        const memberQueryResponse = await this.memberService.gluonMemberFromMemberId(gluonMemberId);
+
+        if (!isSuccessCode(memberQueryResponse.status)) {
+            throw new Error("Unable to find member");
+        }
+
+        const member = memberQueryResponse.data;
+        if (member.slack !== null) {
+            logger.info(`Inviting member: ${member.firstName}`);
+            return await inviteUserToSlackChannel(ctx, slackTeamId, slackChannelId, member.slack.userId);
+        } else {
+            throw new Error("User has no associated slack id to invite");
+        }
+    }
+
+    private async requestNonExistentTeamsCreation(ctx: HandlerContext, gluonTeamName: string, documentationLink: string) {
+        const msg: SlackMessage = {
+            text: `There was an error creating your *${gluonTeamName}* team channel`,
+            attachments: [{
+                text: `
 Unfortunately this team does not seem to exist on Subatomic.
 To create a team channel you must first create a team. Click the button below to do that now.
                                                   `,
-            fallback: "Team does not exist on Subatomic",
-            footer: `For more information, please read the ${documentationLink}`,
-            color: "#D94649",
-            mrkdwn_in: ["text"],
-            actions: [
-                buttonForCommand(
-                    {
-                        text: "Create team",
-                    },
-                    new CreateTeam()),
-            ],
-        }],
-    };
+                fallback: "Team does not exist on Subatomic",
+                footer: `For more information, please read the ${documentationLink}`,
+                color: "#D94649",
+                mrkdwn_in: ["text"],
+                actions: [
+                    buttonForCommand(
+                        {
+                            text: "Create team",
+                        },
+                        new CreateTeam()),
+                ],
+            }],
+        };
 
-    return await ctx.messageClient.respond(msg);
+        return await ctx.messageClient.respond(msg);
+    }
+
 }

--- a/src/gluon/commands/team/TeamSlackChannel.ts
+++ b/src/gluon/commands/team/TeamSlackChannel.ts
@@ -20,7 +20,6 @@ import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {
     handleQMError,
-    logErrorAndReturnSuccess,
     QMError,
     ResponderMessageClient,
 } from "../../util/shared/Error";
@@ -105,7 +104,8 @@ export class NewTeamSlackChannel implements HandleCommand {
     })
     public teamChannel: string;
 
-    constructor(private teamService = new TeamService()) {}
+    constructor(private teamService = new TeamService()) {
+    }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
@@ -158,16 +158,12 @@ export class LinkExistingTeamSlackChannel extends RecursiveParameterRequestComma
 
     protected async setNextParameter(ctx: HandlerContext): Promise<HandlerResult> {
         if (_.isEmpty(this.teamName)) {
-            try {
-                const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(ctx, this.slackScreenName);
-                return await menuForTeams(
-                    ctx,
-                    teams,
-                    this,
-                    "Please select the team you would like to link the slack channel to");
-            } catch (error) {
-                return await logErrorAndReturnSuccess(this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo.name, error);
-            }
+            const teams = await this.teamService.gluonTeamsWhoSlackScreenNameBelongsTo(this.slackScreenName);
+            return await menuForTeams(
+                ctx,
+                teams,
+                this,
+                "Please select the team you would like to link the slack channel to");
         }
     }
 

--- a/src/gluon/events/bitbucket/BitbucketProjectRequested.ts
+++ b/src/gluon/events/bitbucket/BitbucketProjectRequested.ts
@@ -8,11 +8,11 @@ import {
     success,
 } from "@atomist/automation-client";
 import {url} from "@atomist/slack-messages";
-import axios from "axios";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {BitbucketService} from "../../util/bitbucket/Bitbucket";
 import {BitbucketConfiguration} from "../../util/bitbucket/BitbucketConfiguration";
+import {ProjectService} from "../../util/project/ProjectService";
 import {
     handleQMError,
     QMError,
@@ -70,7 +70,7 @@ export class BitbucketProjectRequested implements HandleEvent<any> {
 
     private bitbucketProjectUrl: string;
 
-    constructor(private bitbucketService = new BitbucketService()) {
+    constructor(private bitbucketService = new BitbucketService(), private projectService = new ProjectService()) {
     }
 
     public async handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
@@ -158,7 +158,7 @@ export class BitbucketProjectRequested implements HandleEvent<any> {
 
     private async confirmBitbucketProjectCreatedWithGluon(projectId: string, projectName: string) {
         logger.info(`Confirming Bitbucket project: [${this.bitbucketProjectId}-${this.bitbucketProjectUrl}]`);
-        const confirmBitbucketProjectCreatedResult = await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
+        const confirmBitbucketProjectCreatedResult = await this.projectService.confirmBitbucketProjectCreated(projectId,
             {
                 bitbucketProject: {
                     bitbucketProjectId: this.bitbucketProjectId,

--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -124,7 +124,7 @@ If you haven't already, you might want to:
     }
 
     private docs(): string {
-        return `${url(`${QMConfig.subatomic.docs.baseUrl}/new-to-subatomic`,
+        return `${url(`${QMConfig.subatomic.docs.baseUrl}`,
             "documentation")}`;
     }
 }

--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -12,16 +12,11 @@ import {
 } from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
-import axios from "axios";
 import {QMConfig} from "../../../config/QMConfig";
 import {NewDevOpsEnvironment} from "../../commands/team/DevOpsEnvironment";
 import {AddMemberToTeam} from "../../commands/team/JoinTeam";
-import {
-    ChannelMessageClient,
-    handleQMError,
-    QMError,
-} from "../../util/shared/Error";
-import {isSuccessCode} from "../../util/shared/Http";
+import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {TeamService} from "../../util/team/TeamService";
 
 @EventHandler("Display a helpful message when the bot joins a channel",
     `subscription BotJoinedChannel {
@@ -66,6 +61,9 @@ export class BotJoinedChannel implements HandleEvent<any> {
 
     @MappedParameter(MappedParameters.SlackChannelName)
     public slackChannelName: string;
+
+    constructor(private teamService = new TeamService()) {
+    }
 
     public async handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
         const botJoinedChannel = event.data.UserJoinedChannel[0];
@@ -114,13 +112,7 @@ If you haven't already, you might want to:
     }
 
     private async getTeams(channelName: string) {
-        const teams = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?slackTeamChannel=${channelName}`);
-
-        if (!isSuccessCode(teams.status)) {
-            throw new QMError("Unable to connect to Subatomic. Please check your connection");
-        }
-
-        return teams;
+        return await this.teamService.gluonTeamForSlackTeamChannel(channelName);
     }
 
     private docs(): string {

--- a/src/gluon/events/team/MembersAddedToTeam.ts
+++ b/src/gluon/events/team/MembersAddedToTeam.ts
@@ -16,8 +16,8 @@ import {ProjectService} from "../../util/project/ProjectService";
 import {
     ChannelMessageClient,
     handleQMError,
-    logErrorAndReturnSuccess,
-    OCResultError, QMError,
+    OCResultError,
+    QMError,
 } from "../../util/shared/Error";
 
 @EventHandler("Receive MembershipRequestCreated events", `
@@ -63,7 +63,7 @@ export class MembersAddedToTeam implements HandleEvent<any> {
         try {
             const team = membersAddedToTeamEvent.team;
 
-            const projects = await this.getListOfTeamProjects(ctx, team.name);
+            const projects = await this.getListOfTeamProjects(team.name);
 
             const bitbucketConfiguration = this.getBitbucketConfiguration(membersAddedToTeamEvent);
 
@@ -75,10 +75,10 @@ export class MembersAddedToTeam implements HandleEvent<any> {
         }
     }
 
-    private async getListOfTeamProjects(ctx: HandlerContext, teamName: string) {
+    private async getListOfTeamProjects(teamName: string) {
         let projects;
         try {
-            projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(ctx, teamName, false);
+            projects = await this.projectService.gluonProjectsWhichBelongToGluonTeam(teamName, false);
         } catch (error) {
             throw new QMError(error, "Failed to get list of projects associated with this team.");
         }

--- a/src/gluon/events/team/MembershipRequestClosed.ts
+++ b/src/gluon/events/team/MembershipRequestClosed.ts
@@ -14,7 +14,12 @@ import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/handlers/c
 import {SlackMessage} from "@atomist/slack-messages";
 import axios from "axios";
 import {QMConfig} from "../../../config/QMConfig";
-import {handleQMError, QMError, ResponderMessageClient} from "../../util/shared/Error";
+import {MemberService} from "../../util/member/Members";
+import {
+    handleQMError,
+    QMError,
+    ResponderMessageClient,
+} from "../../util/shared/Error";
 import {isSuccessCode} from "../../util/shared/Http";
 
 @CommandHandler("Close a membership request")
@@ -63,6 +68,9 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
     })
     public approvalStatus: string;
 
+    constructor(private memberService = new MemberService()) {
+    }
+
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         logger.info(`Attempting approval from user: ${this.approverUserName}`);
 
@@ -95,8 +103,7 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
     }
 
     private async updateGluonMembershipRequest(teamId: string, membershipRequestId: string, approvedByMemberId: string, approvalStatus: string) {
-        const updateMembershipRequestResult = await axios.put(
-            `${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
+        const updateMembershipRequestResult = await this.memberService.updateGluonMembershipRequest(teamId,
             {
                 membershipRequests: [
                     {

--- a/src/gluon/events/team/MembershipRequestClosed.ts
+++ b/src/gluon/events/team/MembershipRequestClosed.ts
@@ -91,14 +91,12 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
     }
 
     private async findGluonTeamMember(slackScreenName: string) {
-        const approverMemberQueryResult = await this.memberService.gluonMemberFromScreenName(slackScreenName, false);
-
-        if (!isSuccessCode(approverMemberQueryResult.status)) {
+        try {
+            return await this.memberService.gluonMemberFromScreenName(slackScreenName, false);
+        } catch (error) {
             logger.error("The approver is not a gluon member. This can only happen if the user was deleted before approving this request.");
             throw new QMError("You are no longer a Subatomic user. Membership request closure failed.");
         }
-
-        return approverMemberQueryResult.data._embedded.teamMemberResources[0];
     }
 
     private async updateGluonMembershipRequest(teamId: string, membershipRequestId: string, approvedByMemberId: string, approvalStatus: string) {

--- a/src/gluon/events/team/MembershipRequestClosed.ts
+++ b/src/gluon/events/team/MembershipRequestClosed.ts
@@ -12,7 +12,6 @@ import {
 import {addressSlackUsers} from "@atomist/automation-client/spi/message/MessageClient";
 import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/handlers/command/slack/AssociateRepo";
 import {SlackMessage} from "@atomist/slack-messages";
-import axios from "axios";
 import {QMConfig} from "../../../config/QMConfig";
 import {MemberService} from "../../util/member/Members";
 import {
@@ -92,7 +91,7 @@ export class MembershipRequestClosed implements HandleCommand<HandlerResult> {
     }
 
     private async findGluonTeamMember(slackScreenName: string) {
-        const approverMemberQueryResult = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${slackScreenName}`);
+        const approverMemberQueryResult = await this.memberService.gluonMemberFromScreenName(slackScreenName, false);
 
         if (!isSuccessCode(approverMemberQueryResult.status)) {
             logger.error("The approver is not a gluon member. This can only happen if the user was deleted before approving this request.");

--- a/src/gluon/util/bitbucket/Bitbucket.ts
+++ b/src/gluon/util/bitbucket/Bitbucket.ts
@@ -16,26 +16,32 @@ import {isSuccessCode} from "../shared/Http";
 
 export class BitbucketService {
     public async bitbucketUserFromUsername(username: string): Promise<any> {
+        logger.debug(`Trying to get Bitbucket user from username. username: ${username} `);
         return await bitbucketAxios().get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/admin/users?filter=${username}`);
     }
 
     public async bitbucketProjectFromKey(bitbucketProjectKey: string): Promise<any> {
+        logger.debug(`Trying to get Bitbucket project from project key. bitbucketProjectKey: ${bitbucketProjectKey} `);
         return await bitbucketAxios().get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${bitbucketProjectKey}`);
     }
 
     public bitbucketRepositoriesForProjectKey(bitbucketProjectKey: string): Promise<any> {
+        logger.debug(`Trying to get Bitbucket repositories associated to project key. bitbucketProjectKey: ${bitbucketProjectKey} `);
         return this.getBitbucketResources(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${bitbucketProjectKey}/repos`);
     }
 
     public async bitbucketRepositoryForSlug(bitbucketProjectKey: string, slug: string): Promise<any> {
+        logger.debug(`Trying to get Bitbucket repository associated to project key with given slug. bitbucketProjectKey: ${bitbucketProjectKey}; slug: ${slug} `);
         return await bitbucketAxios().get(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${bitbucketProjectKey}/repos/${slug}`);
     }
 
     public bitbucketProjects() {
+        logger.debug(`Trying to get all Bitbucket projects.`);
         return this.getBitbucketResources(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects`);
     }
 
     public async getBitbucketResources(resourceUri: string, axiosInstance: AxiosInstance = null, currentResources = []) {
+        logger.debug(`Trying to get Bitbucket resources: ${resourceUri} `);
         if (axiosInstance === null) {
             axiosInstance = bitbucketAxios();
         }
@@ -53,30 +59,36 @@ export class BitbucketService {
     }
 
     public async addProjectPermission(projectKey: string, user: string, permission: string = "PROJECT_READ"): Promise<any> {
+        logger.debug(`Trying to add Bitbucket project permissions. projectKey: ${projectKey}; user: ${user}; permission: ${permission} `);
         return await bitbucketAxios().put(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${projectKey}/permissions/users?name=${user}&permission=${permission}`,
             {});
     }
 
     public async addBranchPermissions(projectKey: string, permissionsConfig: any): Promise<any> {
+        logger.debug(`Trying to add Bitbucket branch permissions for project. projectKey: ${projectKey} `);
         return await bitbucketAxios().post(`${QMConfig.subatomic.bitbucket.restUrl}/branch-permissions/2.0/projects/${projectKey}/restrictions`,
             permissionsConfig);
     }
 
     public async addProjectWebHook(projectKey: string, hook: string, data = {}): Promise<any> {
+        logger.debug(`Trying to add project web hook. projectKey: ${projectKey}; hook: ${hook} `);
         return await bitbucketAxios().put(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects/${projectKey}/settings/hooks/${hook}/enabled`,
             data);
     }
 
     public async getDefaultReviewers(projectKey: string): Promise<any> {
+        logger.debug(`Trying to get Bitbucket default reviewers for project. projectKey: ${projectKey} `);
         return await bitbucketAxios().get(`${QMConfig.subatomic.bitbucket.restUrl}/default-reviewers/1.0/projects/${projectKey}/conditions`);
     }
 
     public async addDefaultReviewers(projectKey: string, defaultReviewerConfig: any): Promise<any> {
+        logger.debug(`Trying to add Bitbucket default reviewers for project. projectKey: ${projectKey} `);
         return await bitbucketAxios().post(`${QMConfig.subatomic.bitbucket.restUrl}/default-reviewers/1.0/projects/${projectKey}/condition`,
             defaultReviewerConfig);
     }
 
     public async addBitbucketProjectAccessKeys(projectKey: string) {
+        logger.debug(`Trying to add Bitbucket project access keys. projectKey: ${projectKey} `);
         const accessKeysResult = await bitbucketAxios().post(`${QMConfig.subatomic.bitbucket.restUrl}/keys/1.0/projects/${projectKey}/ssh`,
             {
                 key: {
@@ -98,6 +110,7 @@ export class BitbucketService {
     }
 
     public async createBitbucketProject(projectData: any): Promise<any> {
+        logger.debug(`Trying to create Bitbucket project.`);
         return await bitbucketAxios().post(`${QMConfig.subatomic.bitbucket.restUrl}/api/1.0/projects`,
             projectData);
     }

--- a/src/gluon/util/jenkins/Jenkins.ts
+++ b/src/gluon/util/jenkins/Jenkins.ts
@@ -15,6 +15,7 @@ export class JenkinsService {
                              token: string,
                              gluonProjectName: string,
                              gluonApplicationName: string): AxiosPromise {
+        logger.debug(`Trying to kick of first jenkins build. jenkinsHost: ${jenkinsHost}; token: ${token}; gluonProjectName: ${gluonProjectName}; gluonApplicationName: ${gluonApplicationName} `);
         const axios = jenkinsAxios();
         return axios.post(`https://${jenkinsHost}/job/${_.kebabCase(gluonProjectName).toLowerCase()}/job/${_.kebabCase(gluonApplicationName).toLowerCase()}/build?delay=0sec`,
             "", {
@@ -28,6 +29,7 @@ export class JenkinsService {
                         token: string,
                         gluonProjectName: string,
                         gluonApplicationName: string): AxiosPromise {
+        logger.debug(`Trying to kick of a jenkins build. jenkinsHost: ${jenkinsHost}; token: ${token}; gluonProjectName: ${gluonProjectName}; gluonApplicationName: ${gluonApplicationName} `);
         const axios = jenkinsAxios();
         return axios.post(`https://${jenkinsHost}/job/${_.kebabCase(gluonProjectName).toLowerCase()}/job/${_.kebabCase(gluonApplicationName).toLowerCase()}/job/master/build?delay=0sec`,
             "", {
@@ -41,6 +43,7 @@ export class JenkinsService {
                                    token: string,
                                    gluonProjectId: string,
                                    jenkinsCredentials: any): AxiosPromise {
+        logger.debug(`Trying to create jenkins global credentials. jenkinsHost: ${jenkinsHost}; token: ${token}; gluonProjectId: ${gluonProjectId}`);
         const axios = jenkinsAxios();
         axios.interceptors.request.use(request => {
             if (request.data && (request.headers["Content-Type"].indexOf("application/x-www-form-urlencoded") !== -1)) {
@@ -68,6 +71,7 @@ export class JenkinsService {
                                            jenkinsCredentials: any,
                                            filePath: string,
                                            fileName: string): AxiosPromise {
+        logger.debug(`Trying to create jenkins global credentials from gile. jenkinsHost: ${jenkinsHost}; token: ${token}; gluonProjectId: ${gluonProjectId}; filePath: ${filePath}; fileName: ${fileName}`);
         const FormData = require("form-data");
         const fs = require("fs");
 
@@ -87,6 +91,7 @@ export class JenkinsService {
     }
 
     public async createJenkinsJob(jenkinsHost: string, token: string, gluonProjectName: string, gluonApplicationName, jobConfig: string): Promise<any> {
+        logger.debug(`Trying to create jenkins job. jenkinsHost: ${jenkinsHost}; token: ${token}; gluonProjectName: ${gluonProjectName}; gluonApplicationName: ${gluonApplicationName}`);
         const axios = jenkinsAxios();
         return await axios.post(`https://${jenkinsHost}/job/${_.kebabCase(gluonProjectName).toLowerCase()}/createItem?name=${_.kebabCase(gluonApplicationName).toLowerCase()}`,
             jobConfig,
@@ -99,6 +104,7 @@ export class JenkinsService {
     }
 
     public async createOpenshiftEnvironmentCredentials(jenkinsHost: string, token: string, gluonProjectName: string, credentialsConfig: string): Promise<any> {
+        logger.debug(`Trying to create jenkins openshift credentials. jenkinsHost: ${jenkinsHost}; token: ${token}; gluonProjectName: ${gluonProjectName}`);
         const axios = jenkinsAxios();
         return await axios.post(`https://${jenkinsHost}/createItem?name=${_.kebabCase(gluonProjectName).toLowerCase()}`,
             credentialsConfig,

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -52,6 +52,17 @@ To create a team you must first onboard yourself. Click the button below to do t
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/members`,
             teamMemberDetails);
     }
+
+    public async updateGluonMembershipRequest(teamId: string, membershipRequestDetails: any): Promise<any> {
+        return await axios.put(
+            `${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
+            membershipRequestDetails);
+    }
+
+    public async updateMemberSlackDetails(memberId: string, slackDetails: any): Promise<any> {
+        return await axios.put(
+            `${QMConfig.subatomic.gluon.baseUrl}/members/${memberId}`, slackDetails);
+    }
 }
 
 export function usernameFromDomainUsername(domainUsername: string): string {

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -49,25 +49,30 @@ To create a team you must first onboard yourself. Click the button below to do t
     }
 
     public async gluonMemberFromEmailAddress(emailAddress: string): Promise<any> {
+        logger.debug(`Trying to get member from email address. emailAddress: ${emailAddress}`);
         return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?email=${emailAddress}`);
     }
 
     public async gluonMemberFromMemberId(memberId: string): Promise<any> {
+        logger.debug(`Trying to get member from memberId. memberId: ${memberId}`);
         return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members/${memberId}`);
     }
 
     public async createGluonMember(teamMemberDetails: any): Promise<any> {
+        logger.debug(`Trying to create gluon member.`);
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/members`,
             teamMemberDetails);
     }
 
     public async updateGluonMembershipRequest(teamId: string, membershipRequestDetails: any): Promise<any> {
+        logger.debug(`Trying to update membership request. teamId: ${teamId}`);
         return await axios.put(
             `${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
             membershipRequestDetails);
     }
 
     public async updateMemberSlackDetails(memberId: string, slackDetails: any): Promise<any> {
+        logger.debug(`Trying to update member slack details. memberId: ${memberId}`);
         return await axios.put(
             `${QMConfig.subatomic.gluon.baseUrl}/members/${memberId}`, slackDetails);
     }

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -1,4 +1,4 @@
-import {HandlerContext} from "@atomist/automation-client";
+import {HandlerContext, logger} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
 import axios from "axios";
@@ -10,6 +10,8 @@ export class MemberService {
     public gluonMemberFromScreenName(ctx: HandlerContext,
                                      screenName: string,
                                      message: string = "This command requires an onboarded member"): Promise<any> {
+        logger.debug(`Trying to get gluon member from screen name. screenName: ${screenName} `);
+
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${screenName}`)
             .then(members => {
                 if (!_.isEmpty(members.data._embedded)) {

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -47,6 +47,11 @@ To create a team you must first onboard yourself. Click the button below to do t
                 }
             });
     }
+
+    public async createGluonMember(teamMemberDetails: any): Promise<any> {
+        return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/members`,
+            teamMemberDetails);
+    }
 }
 
 export function usernameFromDomainUsername(domainUsername: string): string {

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -48,6 +48,14 @@ To create a team you must first onboard yourself. Click the button below to do t
         return result.data._embedded.teamMemberResources[0];
     }
 
+    public async gluonMemberFromEmailAddress(emailAddress: string): Promise<any> {
+        return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?email=${emailAddress}`);
+    }
+
+    public async gluonMemberFromMemberId(memberId: string): Promise<any> {
+        return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members/${memberId}`);
+    }
+
     public async createGluonMember(teamMemberDetails: any): Promise<any> {
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/members`,
             teamMemberDetails);

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -2,6 +2,7 @@ import {logger} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
 import axios from "axios";
+import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {OnboardMember} from "../../commands/member/Onboard";
 import {QMError} from "../shared/Error";
@@ -14,7 +15,7 @@ export class MemberService {
 
         const result = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${screenName}`);
 
-        if (!isSuccessCode(result.status)) {
+        if (!isSuccessCode(result.status) || _.isEmpty(result.data._embedded)) {
             const errorMessage = `Failed to get member details. Member ${screenName} appears to not be onboarded.`;
             if (requestOnboardingIfFailure) {
                 const msg: SlackMessage = {

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -1,51 +1,51 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
 import axios from "axios";
-import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {OnboardMember} from "../../commands/member/Onboard";
+import {QMError} from "../shared/Error";
+import {isSuccessCode} from "../shared/Http";
 
 export class MemberService {
-    public gluonMemberFromScreenName(ctx: HandlerContext,
-                                     screenName: string,
-                                     message: string = "This command requires an onboarded member"): Promise<any> {
+    public async gluonMemberFromScreenName(screenName: string,
+                                           requestOnboardingIfFailure: boolean = true): Promise<any> {
         logger.debug(`Trying to get gluon member from screen name. screenName: ${screenName} `);
 
-        return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${screenName}`)
-            .then(members => {
-                if (!_.isEmpty(members.data._embedded)) {
-                    return Promise.resolve(members.data._embedded.teamMemberResources[0]);
-                } else {
-                    // TODO: This does not make sense. Querying a users details does not make you the user. This should be removed.
-                    const msg: SlackMessage = {
-                        text: message,
-                        attachments: [{
-                            text: `
+        const result = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${screenName}`);
+
+        if (!isSuccessCode(result.status)) {
+            const errorMessage = `Failed to get member details. Member ${screenName} appears to not be onboarded.`;
+            if (requestOnboardingIfFailure) {
+                const msg: SlackMessage = {
+                    text: "This command requires the member to be onboarded onto subatomic",
+                    attachments: [{
+                        text: `
 Unfortunately you do not seem to have been onboarded to Subatomic.
 To create a team you must first onboard yourself. Click the button below to do that now.
                             `,
-                            fallback: "You are not onboarded to Subatomic",
-                            footer: `For more information, please read the ${url(`${QMConfig.subatomic.docs.baseUrl}/teams`,
-                                "documentation")}`,
-                            color: "#ffcc00",
-                            mrkdwn_in: ["text"],
-                            thumb_url: "https://raw.githubusercontent.com/absa-subatomic/subatomic-documentation/gh-pages/images/subatomic-logo-colour.png",
-                            actions: [
-                                buttonForCommand(
-                                    {
-                                        text: "Onboard me",
-                                    },
-                                    new OnboardMember()),
-                            ],
-                        }],
-                    };
+                        fallback: "You are not onboarded to Subatomic",
+                        footer: `For more information, please read the ${url(`${QMConfig.subatomic.docs.baseUrl}/teams`,
+                            "documentation")}`,
+                        color: "#ffcc00",
+                        mrkdwn_in: ["text"],
+                        thumb_url: "https://raw.githubusercontent.com/absa-subatomic/subatomic-documentation/gh-pages/images/subatomic-logo-colour.png",
+                        actions: [
+                            buttonForCommand(
+                                {
+                                    text: "Onboard me",
+                                },
+                                new OnboardMember()),
+                        ],
+                    }],
+                };
+                throw new QMError(errorMessage, msg);
+            } else {
+                throw new QMError(errorMessage);
+            }
+        }
 
-                    return ctx.messageClient.respond(msg)
-                        .then(() => Promise.reject(
-                            `Member with screen name ${screenName} is not onboarded`));
-                }
-            });
+        return result.data._embedded.teamMemberResources[0];
     }
 
     public async createGluonMember(teamMemberDetails: any): Promise<any> {

--- a/src/gluon/util/openshift/OCService.ts
+++ b/src/gluon/util/openshift/OCService.ts
@@ -16,18 +16,21 @@ export class OCService {
     }
 
     public async newDevOpsProject(openshiftProjectId: string, teamName: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create new Dev Ops environment. openshiftProjectId: ${openshiftProjectId}; teamName: ${teamName} `);
         return await OCClient.newProject(openshiftProjectId,
             `${teamName} DevOps`,
             `DevOps environment for ${teamName} [managed by Subatomic]`);
     }
 
     public async newSubatomicProject(openshiftProjectId: string, projectName: string, owningTenant: string, environment: string[]): Promise<OCCommandResult> {
+        logger.debug(`Trying to create new Subatomic Project. openshiftProjectId: ${openshiftProjectId}; projectName: ${projectName}; environment: ${JSON.stringify(environment)} `);
         return await OCClient.newProject(openshiftProjectId,
             getProjectDisplayName(owningTenant, projectName, environment[0]),
             `${environment[1]} environment for ${projectName} [managed by Subatomic]`);
     }
 
     public async createDevOpsDefaultResourceQuota(openshiftProjectId: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create Dev Ops default resource quota. openshiftProjectId: ${openshiftProjectId}`);
         return await OCCommon.createFromData({
             apiVersion: "v1",
             kind: "ResourceQuota",
@@ -47,6 +50,7 @@ export class OCService {
     }
 
     public async createDevOpsDefaultLimits(openshiftProjectId: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create Dev Ops default limits. openshiftProjectId: ${openshiftProjectId}`);
         return await OCCommon.createFromData({
             apiVersion: "v1",
             kind: "LimitRange",
@@ -76,6 +80,7 @@ export class OCService {
     }
 
     public async createProjectDefaultResourceQuota(openshiftProjectId: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create project default resource quota. openshiftProjectId: ${openshiftProjectId}`);
         return await OCCommon.createFromData({
             apiVersion: "v1",
             kind: "ResourceQuota",
@@ -97,6 +102,7 @@ export class OCService {
     }
 
     public async createProjectDefaultLimits(openshiftProjectId: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create project default limits. openshiftProjectId: ${openshiftProjectId}`);
         return await OCCommon.createFromData({
             apiVersion: "v1",
             kind: "LimitRange",
@@ -126,6 +132,7 @@ export class OCService {
     }
 
     public async getSubatomicTemplate(templateName: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to get subatomic template. templateName: ${templateName}`);
         return await OCCommon.commonCommand("get", "templates",
             [templateName],
             [
@@ -136,6 +143,7 @@ export class OCService {
     }
 
     public async getSubatomicAppTemplates(namespace = "subatomic"): Promise<OCCommandResult> {
+        logger.debug(`Trying to get subatomic templates. namespace: ${namespace}`);
         return await OCCommon.commonCommand("get", "templates",
             [],
             [
@@ -147,6 +155,7 @@ export class OCService {
     }
 
     public async getJenkinsTemplate(): Promise<OCCommandResult> {
+        logger.debug(`Trying to get jenkins template.`);
         return await OCCommon.commonCommand("get", "templates",
             ["jenkins-persistent-subatomic"],
             [
@@ -157,6 +166,7 @@ export class OCService {
     }
 
     public async getSubatomicImageStreamTags(namespace = "subatomic") {
+        logger.debug(`Trying to get subatomic image stream. namespace: ${namespace}`);
         return OCCommon.commonCommand("get", "istag",
             [],
             [
@@ -168,6 +178,7 @@ export class OCService {
     }
 
     public async createResourceFromDataInNamespace(resourceDefinition: any, projectNamespace: string, applyNotReplace: boolean = false): Promise<OCCommandResult> {
+        logger.debug(`Trying to create resource from data in namespace. projectNamespace: ${projectNamespace}`);
         return await OCCommon.createFromData(resourceDefinition,
             [
                 new SimpleOption("-namespace", projectNamespace),
@@ -176,12 +187,14 @@ export class OCService {
     }
 
     public async tagSubatomicImageToNamespace(imageStreamTagName: string, destinationProjectNamespace: string, destinationImageStreamTagName: string = imageStreamTagName): Promise<OCCommandResult> {
+        logger.debug(`Trying tag subatomic image to namespace. imageStreamTagName: ${imageStreamTagName}; destinationProjectNamespace: ${destinationProjectNamespace}; destingationImageStreamTagName: ${destinationImageStreamTagName}`);
         return await OCCommon.commonCommand("tag",
             `subatomic/${imageStreamTagName}`,
             [`${destinationProjectNamespace}/${destinationImageStreamTagName}`]);
     }
 
     public async processJenkinsTemplateForDevOpsProject(devopsNamespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to process jenkins template for devops project template. devopsNamespace: ${devopsNamespace}`);
         const parameters = [
             `NAMESPACE=${devopsNamespace}`,
             "JENKINS_IMAGE_STREAM_TAG=jenkins-subatomic:2.0",
@@ -199,6 +212,7 @@ export class OCService {
     }
 
     public async processOpenshiftTemplate(templateName: string, namespace: string, parameters: string[], ignoreUnknownParameters: boolean = false) {
+        logger.debug(`Trying to process openshift template in namespace. templateName: ${templateName}; namespace: ${namespace}, paramaters: ${JSON.stringify(parameters)}`);
         const commandOptions: AbstractOption[] = [];
         if (ignoreUnknownParameters) {
             commandOptions.push(new StandardOption("ignore-unknown-parameters", "true"));
@@ -218,6 +232,7 @@ export class OCService {
     }
 
     public async getDeploymentConfigInNamespace(dcName: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to get dc in namespace. dcName: ${dcName}, namespace: ${namespace}`);
         return await OCCommon.commonCommand("get", `dc/${dcName}`, [],
             [
                 new SimpleOption("-namespace", namespace),
@@ -225,6 +240,7 @@ export class OCService {
     }
 
     public async rolloutDeploymentConfigInNamespace(dcName: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to rollout dc in namespace. dcName: ${dcName}, namespace: ${namespace}`);
         return await OCCommon.commonCommand(
             "rollout status",
             `dc/${dcName}`,
@@ -236,6 +252,7 @@ export class OCService {
     }
 
     public async getServiceAccountToken(serviceAccountName: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to get service account token in namespace. serviceAccountName: ${serviceAccountName}, namespace: ${namespace}`);
         return await OCCommon.commonCommand("serviceaccounts",
             "get-token",
             [
@@ -246,6 +263,7 @@ export class OCService {
     }
 
     public async annotateJenkinsRoute(namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to annotate jenkins route in namespace. namespace: ${namespace}`);
         return await OCCommon.commonCommand("annotate route",
             "jenkins",
             [],
@@ -256,6 +274,7 @@ export class OCService {
     }
 
     public async getJenkinsHost(namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to get jenkins host in namespace. namespace: ${namespace}`);
         return await OCCommon.commonCommand(
             "get",
             "route/jenkins",
@@ -267,6 +286,7 @@ export class OCService {
     }
 
     public async getSecretFromNamespace(secretName: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to get secret in namespace. secretName: ${secretName}, namespace: ${namespace}`);
         return await OCCommon.commonCommand("get secrets",
             secretName,
             [],
@@ -276,6 +296,7 @@ export class OCService {
     }
 
     public async createBitbucketSSHAuthSecret(secretName: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create bitbucket ssh auth secret in namespace. secretName: ${secretName}, namespace: ${namespace}`);
         return await OCCommon.commonCommand("secrets new-sshauth",
             secretName,
             [],
@@ -287,6 +308,7 @@ export class OCService {
     }
 
     public async createConfigServerSecret(namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create config server secret. namespace: ${namespace}`);
         return await OCCommon.commonCommand("create secret generic",
             "subatomic-config-server",
             [],
@@ -298,6 +320,7 @@ export class OCService {
     }
 
     public async addTeamMembershipPermissionsToProject(projectId: string, team: { owners: Array<{ domainUsername }>, members: Array<{ domainUsername }> }) {
+        logger.debug(`Trying to add team membership permission to project.`);
         await team.owners.map(async owner => {
             const ownerUsername = /[^\\]*$/.exec(owner.domainUsername)[0];
             logger.info(`Adding role to project [${projectId}] and owner [${owner.domainUsername}]: ${ownerUsername}`);
@@ -315,6 +338,7 @@ export class OCService {
     }
 
     public async createPodNetwork(projectsToJoin: string[], projectToJoinTo: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create pod network. projectsToJoin: ${JSON.stringify(projectsToJoin)}; projectToJoinTo: ${projectToJoinTo}`);
         return await OCCommon.commonCommand(
             "adm pod-network",
             "join-projects",
@@ -325,12 +349,14 @@ export class OCService {
     }
 
     public async addRoleToUserInNamespace(user: string, role: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to add role to user in namespace: user: ${user}; role: ${role}; namespace: ${namespace}`);
         return await OCClient.policy.addRoleToUser(user,
             role,
             namespace);
     }
 
     public async createPVC(pvcName: string, namespace: string): Promise<OCCommandResult> {
+        logger.debug(`Trying to create pvc in namespace. pvcName: ${pvcName}; namespace: ${namespace}`);
         return await OCClient.createPvc(pvcName, namespace);
     }
 }

--- a/src/gluon/util/packages/Applications.ts
+++ b/src/gluon/util/packages/Applications.ts
@@ -1,4 +1,8 @@
-import {HandleCommand, HandlerContext} from "@atomist/automation-client";
+import {
+    HandleCommand,
+    HandlerContext,
+    logger,
+} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
 import axios from "axios";
@@ -15,6 +19,7 @@ export enum ApplicationType {
 
 export class ApplicationService {
     public gluonApplicationsLinkedToGluonProject(ctx: HandlerContext, gluonProjectName: string): Promise<any> {
+        logger.debug(`Trying to get gluon applications associated to projectName. gluonProjectName: ${gluonProjectName} `);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/applications?projectName=${gluonProjectName}`)
             .then(applications => {
                 if (!_.isEmpty(applications.data._embedded)) {
@@ -42,6 +47,7 @@ export class ApplicationService {
                                                  applicationName: string,
                                                  projectName: string,
                                                  message: string = "This command requires an existing application"): Promise<any> {
+        logger.debug(`Trying to get gluon applications associated to name and project. applicationName: ${applicationName}; projectName: ${projectName}`);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/applications?name=${applicationName}&projectName=${projectName}`)
             .then(applications => {
                 if (!_.isEmpty(applications.data._embedded)) {
@@ -79,6 +85,7 @@ Consider creating a new application called ${applicationName}. Click the button 
     }
 
     public gluonApplicationsLinkedToGluonProjectId(gluonProjectId: string): Promise<any[]> {
+        logger.debug(`Trying to get gluon applications associated to project Id. gluonProjectId: ${gluonProjectId} `);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/applications?projectId=${gluonProjectId}`)
             .then(applications => {
                 if (!_.isEmpty(applications.data._embedded)) {

--- a/src/gluon/util/packages/Applications.ts
+++ b/src/gluon/util/packages/Applications.ts
@@ -107,6 +107,7 @@ Consider creating a new application called ${applicationName}. Click the button 
     }
 
     public async createGluonApplication(applicationDetails: any): Promise<any> {
+        logger.debug(`Trying to create application.`);
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/applications`, applicationDetails);
     }
 }

--- a/src/gluon/util/packages/Applications.ts
+++ b/src/gluon/util/packages/Applications.ts
@@ -29,7 +29,11 @@ export class ApplicationService {
             throw new QMError(`Failed to get applications linked to project ${gluonProjectName}`);
         }
 
-        if (requestActionOnFailure && result.data._embedded.applicationResources.isEmpty()) {
+        let returnValue = [];
+
+        if (!_.isEmpty(result.data._embedded)) {
+            returnValue = result.data._embedded.applicationResources;
+        } else if (requestActionOnFailure) {
             const slackMessage: SlackMessage = {
                 text: "Unfortunately there are no applications linked to this project.",
                 attachments: [{
@@ -48,7 +52,7 @@ export class ApplicationService {
             throw new QMError(`No applications linked to project ${gluonProjectName}.`, slackMessage);
         }
 
-        return result.data._embedded.applicationResources;
+        return returnValue;
 
     }
 
@@ -59,7 +63,7 @@ export class ApplicationService {
 
         const result = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/applications?name=${applicationName}&projectName=${projectName}`);
 
-        if (!isSuccessCode(result.status)) {
+        if (!isSuccessCode(result.status) || _.isEmpty(result.data._embedded)) {
             const errorMessage = `Application with name ${applicationName} in project ${projectName} does not exist`;
             if (requestActionOnFailure) {
                 const slackMessage: SlackMessage = {

--- a/src/gluon/util/packages/Applications.ts
+++ b/src/gluon/util/packages/Applications.ts
@@ -94,6 +94,10 @@ Consider creating a new application called ${applicationName}. Click the button 
                 return [];
             });
     }
+
+    public async createGluonApplication(applicationDetails: any): Promise<any> {
+        return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/applications`, applicationDetails);
+    }
 }
 
 export function menuForApplications(ctx: HandlerContext, applications: any[],

--- a/src/gluon/util/project/ProjectService.ts
+++ b/src/gluon/util/project/ProjectService.ts
@@ -117,16 +117,19 @@ Consider creating a new project called ${projectName}. Click the button below to
     }
 
     public async createGluonProject(projectDetails: any): Promise<any> {
+        logger.debug(`Trying to create gluon projects`);
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/projects`,
             projectDetails);
     }
 
     public async confirmBitbucketProjectCreated(projectId: string, bitbucketConfirmationDetails: any): Promise<any> {
+        logger.debug(`Trying to confirm bitbucket project created. projectId: ${projectId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
             bitbucketConfirmationDetails);
     }
 
     public async requestProjectEnvironment(projectId: string, memberId: string): Promise<any> {
+        logger.debug(`Trying to request project environments. projectId: ${projectId}; memberId: ${memberId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
             {
                 projectEnvironment: {
@@ -136,10 +139,12 @@ Consider creating a new project called ${projectName}. Click the button below to
     }
 
     public async associateTeamToProject(projectId: string, associationDetails: any): Promise<any> {
+        logger.debug(`Trying to associate team to project. projectId: ${projectId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`, associationDetails);
     }
 
     public async updateProjectWithBitbucketDetails(projectId: string, bitbucketDetails: any): Promise<any> {
+        logger.debug(`Trying to update project with bitbucket details. projectId: ${projectId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
             bitbucketDetails);
     }

--- a/src/gluon/util/project/ProjectService.ts
+++ b/src/gluon/util/project/ProjectService.ts
@@ -61,26 +61,25 @@ Consider creating a new project called ${projectName}. Click the button below to
         const result = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects?teamName=${teamName}`);
 
         if (!isSuccessCode(result.status)) {
-            const errorMessage = `No projects associated to team ${teamName}`;
-            if (promptToCreateIfNoProjects) {
-                const slackMessage: SlackMessage = {
-                    text: "Unfortunately there are no projects linked to any of your teams with that name.",
-                    attachments: [{
-                        text: "Would you like to create a new project?",
-                        fallback: "Would you like to create a new project?",
-                        actions: [
-                            buttonForCommand(
-                                {
-                                    text: "Create project",
-                                },
-                                new CreateProject()),
-                        ],
-                    }],
-                };
-                throw new QMError(errorMessage, slackMessage);
-            } else {
-                throw new QMError(errorMessage);
-            }
+            throw new QMError(`Failed to get project associated to ${teamName}`);
+        }
+
+        if (promptToCreateIfNoProjects && result.data._embedded.projectResources.isEmpty()) {
+            const slackMessage: SlackMessage = {
+                text: "Unfortunately there are no projects linked to any of your teams with that name.",
+                attachments: [{
+                    text: "Would you like to create a new project?",
+                    fallback: "Would you like to create a new project?",
+                    actions: [
+                        buttonForCommand(
+                            {
+                                text: "Create project",
+                            },
+                            new CreateProject()),
+                    ],
+                }],
+            };
+            throw new QMError(`No projects associated to ${teamName}`, slackMessage);
         }
 
         return result.data._embedded.projectResources;
@@ -93,26 +92,25 @@ Consider creating a new project called ${projectName}. Click the button below to
         const result = await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects`);
 
         if (!isSuccessCode(result.status)) {
-            const errorMessage = `No projects exist.`;
-            if (promptToCreateIfNoProjects) {
-                const slackMessage: SlackMessage = {
-                    text: "Unfortunately there are no projects created yet.",
-                    attachments: [{
-                        text: "Would you like to create a new project?",
-                        fallback: "Would you like to create a new project?",
-                        actions: [
-                            buttonForCommand(
-                                {
-                                    text: "Create project",
-                                },
-                                new CreateProject()),
-                        ],
-                    }],
-                };
-                throw new QMError(errorMessage, slackMessage);
-            } else {
-                throw new QMError(errorMessage);
-            }
+            throw new QMError(`Failed to get projects.`);
+        }
+
+        if (promptToCreateIfNoProjects && result.data._embedded.projectResources.isEmpty()) {
+            const slackMessage: SlackMessage = {
+                text: "Unfortunately there are no projects created yet.",
+                attachments: [{
+                    text: "Would you like to create a new project?",
+                    fallback: "Would you like to create a new project?",
+                    actions: [
+                        buttonForCommand(
+                            {
+                                text: "Create project",
+                            },
+                            new CreateProject()),
+                    ],
+                }],
+            };
+            throw new QMError(`No projects exist yet`, slackMessage);
         }
 
         return result.data._embedded.projectResources;

--- a/src/gluon/util/project/ProjectService.ts
+++ b/src/gluon/util/project/ProjectService.ts
@@ -108,6 +108,29 @@ Consider creating a new project called ${projectName}. Click the button below to
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/projects`,
             projectDetails);
     }
+
+    public async confirmBitbucketProjectCreated(projectId: string, bitbucketConfirmationDetails: any): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
+            bitbucketConfirmationDetails);
+    }
+
+    public async requestProjectEnvironment(projectId: string, memberId: string): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
+            {
+                projectEnvironment: {
+                    requestedBy: memberId,
+                },
+            });
+    }
+
+    public async associateTeamToProject(projectId: string, associationDetails: any): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`, associationDetails);
+    }
+
+    public async updateProjectWithBitbucketDetails(projectId: string, bitbucketDetails: any): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/projects/${projectId}`,
+            bitbucketDetails);
+    }
 }
 
 export function menuForProjects(ctx: HandlerContext, projects: any[],

--- a/src/gluon/util/project/ProjectService.ts
+++ b/src/gluon/util/project/ProjectService.ts
@@ -1,4 +1,8 @@
-import {HandleCommand, HandlerContext} from "@atomist/automation-client";
+import {
+    HandleCommand,
+    HandlerContext,
+    logger,
+} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
 import axios from "axios";
@@ -11,6 +15,7 @@ export class ProjectService {
     public gluonProjectFromProjectName(ctx: HandlerContext,
                                        projectName: string,
                                        message: string = "This command requires an existing project"): Promise<any> {
+        logger.debug(`Trying to get gluon project by projectName. projectName: ${projectName} `);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects?name=${projectName}`)
             .then(projects => {
                 if (!_.isEmpty(projects.data._embedded)) {
@@ -48,6 +53,7 @@ Consider creating a new project called ${projectName}. Click the button below to
     }
 
     public gluonProjectsWhichBelongToGluonTeam(ctx: HandlerContext, teamName: string, promptToCreateIfNoProjects = true): Promise<any[]> {
+        logger.debug(`Trying to get gluon projects associated to team. teamName: ${teamName} `);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects?teamName=${teamName}`)
             .then(projects => {
                 if (!_.isEmpty(projects.data._embedded)) {
@@ -74,6 +80,7 @@ Consider creating a new project called ${projectName}. Click the button below to
     }
 
     public gluonProjectList(ctx: HandlerContext): Promise<any[]> {
+        logger.debug(`Trying to get all gluon projects.`);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/projects`)
             .then(projects => {
                 if (!_.isEmpty(projects.data._embedded)) {

--- a/src/gluon/util/project/ProjectService.ts
+++ b/src/gluon/util/project/ProjectService.ts
@@ -103,6 +103,11 @@ Consider creating a new project called ${projectName}. Click the button below to
                     .then(() => Promise.reject(`Currently no existing projects.`));
             });
     }
+
+    public async createGluonProject(projectDetails: any): Promise<any> {
+        return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/projects`,
+            projectDetails);
+    }
 }
 
 export function menuForProjects(ctx: HandlerContext, projects: any[],

--- a/src/gluon/util/shared/Error.ts
+++ b/src/gluon/util/shared/Error.ts
@@ -22,7 +22,7 @@ export async function handleQMError(messageClient: QMMessageClient, error) {
         return await messageClient.send(`❗Unexpected failure. An external service dependency appears to be down.`);
     } else if (error instanceof QMError) {
         logger.error(`Error is of QMError type. Error: ${error.message}`);
-        return await messageClient.send(`${error.getSlackMessage()}`);
+        return await messageClient.send(error.getSlackMessage());
     } else if (error instanceof Error) {
         logger.error(`Error is of default Error type.\nError: ${util.inspect(error)}`);
         return await messageClient.send(`❗Unhandled exception occurred. Please alert your system admin to check the logs and correct the issue accordingly.`);
@@ -47,7 +47,9 @@ export class QMError extends Error {
 
     public getSlackMessage() {
         if (this.slackMessage === null) {
-            return `❗${this.message}`;
+            return {
+                text: `❗${this.message}`,
+            };
         }
         return this.slackMessage;
     }

--- a/src/gluon/util/team/TeamService.ts
+++ b/src/gluon/util/team/TeamService.ts
@@ -64,6 +64,7 @@ export class TeamService {
     }
 
     public async getAllTeams(): Promise<any> {
+        logger.debug(`Trying to get all teams.`);
         return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams`);
     }
 
@@ -74,6 +75,7 @@ export class TeamService {
     }
 
     public async createGluonTeam(teamName: string, teamDescription: string, createdBy: string): Promise<any> {
+        logger.debug(`Trying to create team. teamName: ${teamName}; teamDescription: ${teamDescription}; createdBy: ${createdBy}`);
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/teams`, {
             name: teamName,
             description: teamDescription,
@@ -82,20 +84,24 @@ export class TeamService {
     }
 
     public async addSlackDetailsToTeam(teamId: string, slackDetails: any): Promise<any> {
+        logger.debug(`Trying to update team slack details. teamId: ${teamId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`, slackDetails);
     }
 
     public async addMemberToTeam(teamId: string, memberDetails: any): Promise<any> {
+        logger.debug(`Trying to add member member to team. teamId: ${teamId}`);
         return await axios.put(teamId,
             memberDetails);
     }
 
     public async createMembershipRequest(teamId: string, membershipRequestDetails: any): Promise<any> {
+        logger.debug(`Trying to create membership request. teamId: ${teamId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
             membershipRequestDetails);
     }
 
     public async requestDevOpsEnvironment(teamId: string, memberId: string): Promise<any> {
+        logger.debug(`Trying to request team devops environment. teamId: ${teamId}, memberId: ${memberId}`);
         return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
             {
                 devOpsEnvironment: {

--- a/src/gluon/util/team/TeamService.ts
+++ b/src/gluon/util/team/TeamService.ts
@@ -58,6 +58,14 @@ export class TeamService {
                 }
             });
     }
+
+    public async createGluonTeam(teamName: string, teamDescription: string, createdBy: string): Promise<any> {
+        return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/teams`, {
+            name: teamName,
+            description: teamDescription,
+            createdBy,
+        });
+    }
 }
 
 export function menuForTeams(ctx: HandlerContext, teams: any[],

--- a/src/gluon/util/team/TeamService.ts
+++ b/src/gluon/util/team/TeamService.ts
@@ -66,6 +66,29 @@ export class TeamService {
             createdBy,
         });
     }
+
+    public async addSlackDetailsToTeam(teamId: string, slackDetails: any): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`, slackDetails);
+    }
+
+    public async addMemberToTeam(teamId: string, memberDetails: any): Promise<any> {
+        return await axios.put(teamId,
+            memberDetails);
+    }
+
+    public async createMembershipRequest(teamId: string, membershipRequestDetails: any): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
+            membershipRequestDetails);
+    }
+
+    public async requestDevOpsEnvironment(teamId: string, memberId: string): Promise<any> {
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
+            {
+                devOpsEnvironment: {
+                    requestedBy: memberId,
+                },
+            });
+    }
 }
 
 export function menuForTeams(ctx: HandlerContext, teams: any[],

--- a/src/gluon/util/team/TeamService.ts
+++ b/src/gluon/util/team/TeamService.ts
@@ -1,4 +1,8 @@
-import {HandleCommand, HandlerContext} from "@atomist/automation-client";
+import {
+    HandleCommand,
+    HandlerContext,
+    logger,
+} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import axios from "axios";
 import * as _ from "lodash";
@@ -9,6 +13,7 @@ import {createMenu} from "../shared/GenericMenu";
 
 export class TeamService {
     public gluonTeamsWhoSlackScreenNameBelongsTo(ctx: HandlerContext, screenName: string): Promise<any[]> {
+        logger.debug(`Trying to get gluon teams associated to a screenName. screenName: ${screenName} `);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?slackScreenName=${screenName}`)
             .then(teams => {
                 if (!_.isEmpty(teams.data._embedded)) {
@@ -39,6 +44,7 @@ export class TeamService {
     }
 
     public gluonTeamForSlackTeamChannel(teamChannel: string): Promise<any> {
+        logger.debug(`Trying to get gluon team associated to a teamChannel. teamChannel: ${teamChannel} `);
         return axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?slackTeamChannel=${teamChannel}`)
             .then(teams => {
                 if (!_.isEmpty(teams.data._embedded)) {

--- a/src/gluon/util/team/TeamService.ts
+++ b/src/gluon/util/team/TeamService.ts
@@ -96,7 +96,7 @@ export class TeamService {
 
     public async addMemberToTeam(teamId: string, memberDetails: any): Promise<any> {
         logger.debug(`Trying to add member member to team. teamId: ${teamId}`);
-        return await axios.put(teamId,
+        return await axios.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`,
             memberDetails);
     }
 

--- a/src/gluon/util/team/TeamService.ts
+++ b/src/gluon/util/team/TeamService.ts
@@ -63,6 +63,16 @@ export class TeamService {
 
     }
 
+    public async getAllTeams(): Promise<any> {
+        return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams`);
+    }
+
+    public async gluonTeamByName(teamName: string): Promise<any> {
+        logger.debug(`Trying to get gluon team with by name. teamName: ${teamName} `);
+
+        return await axios.get(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${teamName}`);
+    }
+
     public async createGluonTeam(teamName: string, teamDescription: string, createdBy: string): Promise<any> {
         return await axios.post(`${QMConfig.subatomic.gluon.baseUrl}/teams`, {
             name: teamName,


### PR DESCRIPTION
Logging added to all gluon calls. Any gluon calls were moved into the gluon services to facilitate the logging in one single place. This required a fair amount of refactoring but this should also be the final abstraction of integration points. The gluon integration leaves something to be desired still but that can be solved at a later stage (see #227).

Resolves #240 