### PR TITLE
Default project template

### DIFF
--- a/resources/templates/openshift/project/base-project-template.json
+++ b/resources/templates/openshift/project/base-project-template.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "v1",
+  "kind": "Template",
+  "metadata": {
+    "name": "subatomic-base-project-template"
+  },
+  "objects": []
+}

--- a/src/gluon/events/project/ProjectEnvironmentsRequested.ts
+++ b/src/gluon/events/project/ProjectEnvironmentsRequested.ts
@@ -192,10 +192,10 @@ export class ProjectEnvironmentsRequested implements HandleEvent<any> {
                 environmentsRequestedEvent.project.name,
                 environmentsRequestedEvent.owningTenant.name,
                 environment);
-            await this.ocService.initilizeProjectWithDefaultProjectTemplate(projectId);
         } catch (err) {
             logger.warn(err);
         } finally {
+            await this.ocService.initilizeProjectWithDefaultProjectTemplate(projectId);
             await environmentsRequestedEvent.teams.map(async team => {
                 await this.ocService.addTeamMembershipPermissionsToProject(projectId, team);
             });

--- a/src/gluon/events/project/ProjectEnvironmentsRequested.ts
+++ b/src/gluon/events/project/ProjectEnvironmentsRequested.ts
@@ -16,9 +16,7 @@ import {LinkExistingApplication} from "../../commands/packages/LinkExistingAppli
 import {LinkExistingLibrary} from "../../commands/packages/LinkExistingLibrary";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
 import {OCService} from "../../services/openshift/OCService";
-import {
-    getProjectId,
-} from "../../util/project/Project";
+import {getProjectId} from "../../util/project/Project";
 import {
     ChannelMessageClient,
     handleQMError,
@@ -189,11 +187,12 @@ export class ProjectEnvironmentsRequested implements HandleEvent<any> {
 
     private async createOpenshiftProject(projectId: string, environmentsRequestedEvent, environment) {
         try {
-            return await this.ocService.newSubatomicProject(
+            await this.ocService.newSubatomicProject(
                 projectId,
                 environmentsRequestedEvent.project.name,
                 environmentsRequestedEvent.owningTenant.name,
                 environment);
+            await this.ocService.initilizeProjectWithDefaultProjectTemplate(projectId);
         } catch (err) {
             logger.warn(err);
         } finally {

--- a/src/gluon/util/resources/BaseProjectTemplateLoader.ts
+++ b/src/gluon/util/resources/BaseProjectTemplateLoader.ts
@@ -1,0 +1,10 @@
+import {JsonLoader} from "./JsonLoader";
+
+export class BaseProjectTemplateLoader extends JsonLoader {
+
+    private readonly PROJECT_TEMPLATE_DIR = "/resources/templates/openshift/project/";
+
+    public getTemplate(parameters: { [k: string]: any } = {}) {
+        return this.readTemplatizedFileContents(`${this.PROJECT_TEMPLATE_DIR}devops-default-resource-quota.json`, parameters);
+    }
+}

--- a/src/gluon/util/resources/BaseProjectTemplateLoader.ts
+++ b/src/gluon/util/resources/BaseProjectTemplateLoader.ts
@@ -2,9 +2,9 @@ import {JsonLoader} from "./JsonLoader";
 
 export class BaseProjectTemplateLoader extends JsonLoader {
 
-    private readonly PROJECT_TEMPLATE_DIR = "/resources/templates/openshift/project/";
+    private readonly PROJECT_TEMPLATE_DIR = "resources/templates/openshift/project/";
 
     public getTemplate(parameters: { [k: string]: any } = {}) {
-        return this.readTemplatizedFileContents(`${this.PROJECT_TEMPLATE_DIR}devops-default-resource-quota.json`, parameters);
+        return this.readTemplatizedFileContents(`${this.PROJECT_TEMPLATE_DIR}base-project-template.json`, parameters);
     }
 }

--- a/src/gluon/util/resources/JsonLoader.ts
+++ b/src/gluon/util/resources/JsonLoader.ts
@@ -1,0 +1,14 @@
+import {QMTemplate} from "../../../template/QMTemplate";
+
+export class JsonLoader {
+    protected readFileContents(filePath: string): string {
+        const fs = require("fs");
+        const buffer = fs.readFileSync(filePath);
+        return JSON.parse(buffer.toString());
+    }
+
+    protected readTemplatizedFileContents(filePath: string, parameters: { [k: string]: any }) {
+        const template = new QMTemplate(filePath);
+        return JSON.parse(template.build(parameters));
+    }
+}

--- a/src/gluon/util/resources/QuotaLoader.ts
+++ b/src/gluon/util/resources/QuotaLoader.ts
@@ -1,26 +1,23 @@
-export class QuotaLoader {
+import {JsonLoader} from "./JsonLoader";
+
+export class QuotaLoader extends JsonLoader {
 
     private readonly QUOTA_DIRECTORY = "/resources/quotas/";
 
     public getDevOpsDefaultResourceQuota() {
-        return this.readQuotaFileContents("devops-default-resource-quota.json");
+        return this.readFileContents(`${this.QUOTA_DIRECTORY}devops-default-resource-quota.json`);
     }
 
     public getDevOpsDefaultLimitRange() {
-        return this.readQuotaFileContents("devops-default-limit-range.json");
+        return this.readFileContents(`${this.QUOTA_DIRECTORY}devops-default-limit-range.json`);
     }
 
     public getProjectDefaultResourceQuota() {
-        return this.readQuotaFileContents("project-default-resource-quota.json");
+        return this.readFileContents(`${this.QUOTA_DIRECTORY}project-default-resource-quota.json`);
     }
 
     public getProjectDefaultLimitRange() {
-        return this.readQuotaFileContents("project-default-limit-range.json");
+        return this.readFileContents(`${this.QUOTA_DIRECTORY}project-default-limit-range.json`);
     }
 
-    private readQuotaFileContents(fileName: string): string {
-        const fs = require("fs");
-        const buffer = fs.readFileSync(`${this.QUOTA_DIRECTORY}${fileName}`);
-        return buffer.toString();
-    }
 }

--- a/src/gluon/util/resources/QuotaLoader.ts
+++ b/src/gluon/util/resources/QuotaLoader.ts
@@ -2,7 +2,7 @@ import {JsonLoader} from "./JsonLoader";
 
 export class QuotaLoader extends JsonLoader {
 
-    private readonly QUOTA_DIRECTORY = "/resources/quotas/";
+    private readonly QUOTA_DIRECTORY = "resources/quotas/";
 
     public getDevOpsDefaultResourceQuota() {
         return this.readFileContents(`${this.QUOTA_DIRECTORY}devops-default-resource-quota.json`);

--- a/src/template/QMTemplate.ts
+++ b/src/template/QMTemplate.ts
@@ -1,17 +1,16 @@
-import {logger} from "@atomist/automation-client";
 import * as Handlebars from "handlebars";
 
 export class QMTemplate {
 
     private readonly template: HandlebarsTemplateDelegate;
 
-    constructor(templateFile: string, trimLines = false) {
+    constructor(templateFile: string) {
         const fs = require("fs");
         const buffer = fs.readFileSync(templateFile);
         this.template = Handlebars.compile(buffer.toString());
     }
 
-    public build(parameters: { [k: string]: any }) {
+    public build(parameters: { [k: string]: any }): string {
         const safeParameters: { [k: string]: any } = Object.assign([], parameters);
         this.toSafeStrings(safeParameters);
         return this.template(safeParameters);


### PR DESCRIPTION
Execute a default project template when creating project environments. The default template is empty but can be modified without code changes. Currently we do not pass any parameters to the template because not sure what parameters would be useful. Can adjust as necessary.

Resolves #258 