### PR TITLE
Add more info to assist with private channels

### DIFF
--- a/src/gluon/services/team/TeamSlackChannelService.ts
+++ b/src/gluon/services/team/TeamSlackChannelService.ts
@@ -29,9 +29,11 @@ export class TeamSlackChannelService {
 
         const channel = await this.createTeamSlackChannel(ctx, slackTeamId, slackChannelName);
 
-        await this.inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.members);
+        if (channel.createSlackChannel != null) {
+            await this.inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.members);
 
-        await this.inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.owners);
+            await this.inviteListOfGluonMembersToChannel(ctx, slackTeamId, channel.createSlackChannel.id, slackChannelName, team.owners);
+        }
 
     }
 
@@ -78,8 +80,9 @@ export class TeamSlackChannelService {
             // allow error to fall through to final return otherwise
         } catch (err) {
             if (err.networkError && err.networkError.response && err.networkError.response.status === 400) {
-                return await ctx.messageClient.respond(`The channel has been successfully linked to your team but since the channel "${slackChannelName}" is private` +
-                    ` the atomist bot cannot be automatically invited. Please manually invite the atomist bot using the \`/invite @atomist\` command in the "${slackChannelName}" slack channel.`);
+                return await ctx.messageClient.respond(`❗ The channel has been successfully linked to your team but since the channel *${slackChannelName}* is private` +
+                    ` the atomist bot cannot be automatically invited. Please manually invite the atomist bot using the \`/invite @atomist\` command in the *${slackChannelName}* slack channel.` +
+                    ` You will then need to manually invite your team members to the *${slackChannelName}* channel using the \`/invite @teamMembersName\`.`);
             }
             // allow error to fall through to final return otherwise
         }

--- a/test/gluon/services/team/TeamSlackChannelServiceTest.ts
+++ b/test/gluon/services/team/TeamSlackChannelServiceTest.ts
@@ -134,7 +134,7 @@ describe("TeamSlackChannelService createTeamSlackChannel", () => {
 
         await service.createTeamSlackChannel(fakeContext, "Team1Id", "channelName");
 
-        assert(fakeContext.messageClient.textMsg[0].indexOf("The channel has been successfully linked to your team but since the channel \"channelName\" is private") > -1);
+        assert(fakeContext.messageClient.textMsg[0].indexOf("❗ The channel has been successfully linked to your team but since the channel \*channelName\* is private") > -1);
     });
     it("should create channel and add bot", async () => {
 


### PR DESCRIPTION
Won't try send invites to a private channel. Need to possibly speak to Atomist to resolve the mutation regarding invite a user to a private channel.

(lifecycle-automation/src/graphql/mutation/inviteUserToSlackChannel.graphql)

Resolves #260 