### PR TITLE
Generic prod request

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -57,6 +57,7 @@ import {
     BitbucketProjectAddedEvent,
     BitbucketProjectRequestedEvent,
 } from "./gluon/ingesters/bitbucketIngester";
+import {GenericProdRequestedEvent} from "./gluon/ingesters/genericProdRequested";
 import {
     ProjectCreatedEvent,
     ProjectEnvironmentsRequestedEvent,
@@ -173,6 +174,7 @@ export const configuration: any = {
         TeamDevOpsDetails,
         GluonApplication,
         ApplicationProdRequestedEvent,
+        GenericProdRequestedEvent,
     ],
     token,
     http,

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -13,6 +13,7 @@ import {LinkExistingApplication} from "./gluon/commands/packages/LinkExistingApp
 import {LinkExistingLibrary} from "./gluon/commands/packages/LinkExistingLibrary";
 import {AddConfigServer} from "./gluon/commands/project/AddConfigServer";
 import {AssociateTeam} from "./gluon/commands/project/AssociateTeam";
+import {CreateGenericProd} from "./gluon/commands/project/CreateGenericProd";
 import {CreateOpenShiftPvc} from "./gluon/commands/project/CreateOpenShiftPvc";
 import {CreateProject} from "./gluon/commands/project/CreateProject";
 import {CreateProjectProdEnvironments} from "./gluon/commands/project/CreateProjectProdEnvironments";
@@ -21,6 +22,7 @@ import {
     ListProjectDetails,
     ListTeamProjects,
 } from "./gluon/commands/project/ProjectDetails";
+import {ReRunProjectProdRequest} from "./gluon/commands/project/ReRunProjectProdRequest";
 import {UpdateProjectProdRequest} from "./gluon/commands/project/UpdateProjectProdRequest";
 import {AddMemberToTeam} from "./gluon/commands/team/AddMemberToTeam";
 import {CreateMembershipRequestToTeam} from "./gluon/commands/team/CreateMembershipRequestToTeam";
@@ -37,6 +39,7 @@ import {BitbucketProjectRequested} from "./gluon/events/bitbucket/BitbucketProje
 import {TeamMemberCreated} from "./gluon/events/member/TeamMemberCreated";
 import {ApplicationCreated} from "./gluon/events/packages/ApplicationCreated";
 import {ApplicationProdRequested} from "./gluon/events/packages/ApplicationProdRequested";
+import {GenericProdRequested} from "./gluon/events/project/GenericProdRequested";
 import {ProjectCreated} from "./gluon/events/project/ProjectCreated";
 import {ProjectEnvironmentsRequested} from "./gluon/events/project/ProjectEnvironmentsRequested";
 import {ProjectProductionEnvironmentsRequestClosed} from "./gluon/events/project/ProjectProductionEnvironmentsRequestClosed";
@@ -128,6 +131,8 @@ export const configuration: any = {
         CreateProjectProdEnvironments,
         CreateApplicationProd,
         UpdateProjectProdRequest,
+        CreateGenericProd,
+        ReRunProjectProdRequest,
     ],
     events: [
         TeamsLinkedToProject,
@@ -145,6 +150,7 @@ export const configuration: any = {
         ProjectProductionEnvironmentsRequested,
         ApplicationProdRequested,
         ProjectProductionEnvironmentsRequestClosed,
+        GenericProdRequested,
     ],
     ingesters: [
         SlackIdentity,

--- a/src/gluon/commands/packages/CreateApplicationProd.ts
+++ b/src/gluon/commands/packages/CreateApplicationProd.ts
@@ -200,15 +200,11 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
 
         const openShiftResources = JSON.parse(this.openShiftResourcesJSON);
 
-        // logger.info("Current resources JSON = " + this.openShiftResourcesJSON);
-
         const request = {
             applicationId: application.applicationId,
             actionedBy: actionedBy.memberId,
             openShiftResources,
         };
-
-        logger.info(`Prod request: ${JSON.stringify(request, null, 2)}`);
 
         await this.gluonService.prod.application.createApplicationProdRequest(request);
     }

--- a/src/gluon/commands/project/CreateGenericProd.ts
+++ b/src/gluon/commands/project/CreateGenericProd.ts
@@ -9,20 +9,18 @@ import {
 } from "@atomist/automation-client";
 import {v4 as uuid} from "uuid";
 import {QMConfig} from "../../../config/QMConfig";
-import {ApplicationProdRequestMessages} from "../../messages/package/ApplicationProdRequestMessages";
+import {GenericProdRequestMessages} from "../../messages/project/GenericProdRequestMessages";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
-import {PackageOpenshiftResourceService} from "../../services/packages/PackageOpenshiftResourceService";
+import {GenericOpenshiftResourceService} from "../../services/projects/GenericOpenshiftResourceService";
 import {
     getHighestPreProdEnvironment,
     getResourceDisplayMessage,
 } from "../../util/openshift/Helpers";
 import {getProjectId} from "../../util/project/Project";
 import {
-    GluonApplicationNameSetter,
     GluonProjectNameSetter,
     GluonTeamNameSetter,
-    setGluonApplicationName,
     setGluonProjectName,
     setGluonTeamName,
 } from "../../util/recursiveparam/GluonParameterSetters";
@@ -38,13 +36,12 @@ import {
     ResponderMessageClient,
 } from "../../util/shared/Error";
 
-@CommandHandler("Create application in prod", QMConfig.subatomic.commandPrefix + " request application prod")
-export class CreateApplicationProd extends RecursiveParameterRequestCommand
-    implements GluonTeamNameSetter, GluonProjectNameSetter, GluonApplicationNameSetter {
+@CommandHandler("Move openshift resources to prod", QMConfig.subatomic.commandPrefix + " request generic prod")
+export class CreateGenericProd extends RecursiveParameterRequestCommand
+    implements GluonTeamNameSetter, GluonProjectNameSetter {
 
     private static RecursiveKeys = {
         teamName: "TEAM_NAME",
-        applicationName: "APPLICATION_NAME",
         projectName: "PROJECT_NAME",
     };
 
@@ -55,19 +52,13 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
     public teamChannel: string;
 
     @RecursiveParameter({
-        recursiveKey: CreateApplicationProd.RecursiveKeys.teamName,
+        recursiveKey: CreateGenericProd.RecursiveKeys.teamName,
         selectionMessage: "Please select a team associated with the project you wish to configure the package for",
     })
     public teamName: string;
 
     @RecursiveParameter({
-        recursiveKey: CreateApplicationProd.RecursiveKeys.applicationName,
-        selectionMessage: "Please select the package you wish to configure",
-    })
-    public applicationName: string;
-
-    @RecursiveParameter({
-        recursiveKey: CreateApplicationProd.RecursiveKeys.projectName,
+        recursiveKey: CreateGenericProd.RecursiveKeys.projectName,
         selectionMessage: "Please select the owning project of the package you wish to configure",
     })
     public projectName: string;
@@ -90,9 +81,9 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
     })
     public openShiftResourcesJSON: string;
 
-    private applicationProdRequestMessages = new ApplicationProdRequestMessages();
+    private genericProdRequestMessages = new GenericProdRequestMessages();
 
-    constructor(public gluonService = new GluonService(), public ocService = new OCService(), public packageOpenshiftResourceService = new PackageOpenshiftResourceService()) {
+    constructor(public gluonService = new GluonService(), public ocService = new OCService(), public genericOpenshiftResourceService = new GenericOpenshiftResourceService()) {
         super();
     }
 
@@ -106,7 +97,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
                 return await this.getRequestConfirmation(qmMessageClient);
             } else if (this.approval === ApprovalEnum.APPROVED) {
 
-                await this.createApplicationProdRequest();
+                await this.createGenericProdRequest();
 
                 return await qmMessageClient.send(this.getConfirmationResultMesssage(this.approval), {id: this.correlationId});
             } else if (this.approval === ApprovalEnum.REJECTED) {
@@ -119,9 +110,8 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
     }
 
     protected configureParameterSetters() {
-        this.addRecursiveSetter(CreateApplicationProd.RecursiveKeys.teamName, setGluonTeamName);
-        this.addRecursiveSetter(CreateApplicationProd.RecursiveKeys.projectName, setGluonProjectName);
-        this.addRecursiveSetter(CreateApplicationProd.RecursiveKeys.applicationName, setGluonApplicationName);
+        this.addRecursiveSetter(CreateGenericProd.RecursiveKeys.teamName, setGluonTeamName);
+        this.addRecursiveSetter(CreateGenericProd.RecursiveKeys.projectName, setGluonProjectName);
     }
 
     private getConfirmationResultMesssage(result: ApprovalEnum) {
@@ -154,7 +144,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
 
         await this.findAndListResources(qmMessageClient);
 
-        const message = this.applicationProdRequestMessages.confirmProdRequest(this);
+        const message = this.genericProdRequestMessages.confirmProdRequest(this);
 
         return await qmMessageClient.send(message, {id: this.correlationId});
     }
@@ -169,8 +159,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
 
         const allResources = await this.ocService.exportAllResources(getProjectId(tenant.name, project.name, getHighestPreProdEnvironment().id));
 
-        const resources = await this.packageOpenshiftResourceService.getAllApplicationRelatedResources(
-            this.applicationName,
+        const resources = await this.genericOpenshiftResourceService.getAllPromotableResources(
             allResources,
         );
 
@@ -191,25 +180,21 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
 
     }
 
-    private async createApplicationProdRequest() {
+    private async createGenericProdRequest() {
         const project = await this.gluonService.projects.gluonProjectFromProjectName(this.projectName);
-
-        const application = await this.gluonService.applications.gluonApplicationForNameAndProjectName(this.applicationName, project.name);
 
         const actionedBy = await this.gluonService.members.gluonMemberFromScreenName(this.screenName, false);
 
         const openShiftResources = JSON.parse(this.openShiftResourcesJSON);
 
-        // logger.info("Current resources JSON = " + this.openShiftResourcesJSON);
-
         const request = {
-            applicationId: application.applicationId,
+            projectId: project.projectId,
             actionedBy: actionedBy.memberId,
             openShiftResources,
         };
 
         logger.info(`Prod request: ${JSON.stringify(request, null, 2)}`);
 
-        await this.gluonService.prod.application.createApplicationProdRequest(request);
+        await this.gluonService.prod.generic.createGenericProdRequest(request);
     }
 }

--- a/src/gluon/commands/project/CreateGenericProd.ts
+++ b/src/gluon/commands/project/CreateGenericProd.ts
@@ -188,8 +188,12 @@ export class CreateGenericProd extends RecursiveParameterRequestCommand
         const openShiftResources = JSON.parse(this.openShiftResourcesJSON);
 
         const request = {
-            projectId: project.projectId,
-            actionedBy: actionedBy.memberId,
+            project: {
+                projectId: project.projectId,
+            },
+            actionedBy: {
+                memberId: actionedBy.memberId,
+            },
             openShiftResources,
         };
 

--- a/src/gluon/commands/project/ReRunProjectProdRequest.ts
+++ b/src/gluon/commands/project/ReRunProjectProdRequest.ts
@@ -1,0 +1,62 @@
+import {
+    CommandHandler,
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+    logger,
+    MappedParameter,
+    MappedParameters,
+    Parameter,
+    Tags,
+} from "@atomist/automation-client";
+import {addressEvent} from "@atomist/automation-client/spi/message/MessageClient";
+import {GluonService} from "../../services/gluon/GluonService";
+import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+
+@CommandHandler("Re-run a failed project production request")
+@Tags("subatomic", "openshiftProd", "project")
+export class ReRunProjectProdRequest implements HandleCommand<HandlerResult> {
+
+    @MappedParameter(MappedParameters.SlackUserName)
+    public screenName: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public teamChannel: string;
+
+    @Parameter({
+        required: true,
+        description: "correlation id of the message that invoked this command",
+    })
+    public correlationId: string;
+
+    @Parameter({
+        required: true,
+        description: "project prod request id",
+    })
+    public projectProdRequestId: string;
+
+    constructor(public gluonService = new GluonService()) {
+    }
+
+    public async handle(ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info("ReRunning Project Prod Request");
+
+        try {
+            await ctx.messageClient.addressChannels({
+                text: `Ru-running Project Prod Request`,
+            }, this.teamChannel, {id: this.correlationId});
+
+            const projectProdRequestEvent = {
+                projectProdRequestId: this.projectProdRequestId,
+            };
+
+            return await ctx.messageClient.send(projectProdRequestEvent, addressEvent("ProjectProductionEnvironmentsRequestClosedEvent"));
+        } catch (error) {
+            return await this.handleError(ctx, error);
+        }
+    }
+
+    private async handleError(ctx: HandlerContext, error) {
+        return await handleQMError(new ResponderMessageClient(ctx), error);
+    }
+}

--- a/src/gluon/events/project/GenericProdRequested.ts
+++ b/src/gluon/events/project/GenericProdRequested.ts
@@ -1,0 +1,89 @@
+import {
+    EventFired,
+    EventHandler,
+    HandleEvent,
+    HandlerContext,
+    HandlerResult,
+    logger,
+} from "@atomist/automation-client";
+import {QMConfig} from "../../../config/QMConfig";
+import {GluonService} from "../../services/gluon/GluonService";
+import {OCService} from "../../services/openshift/OCService";
+import {CreateOpenshiftResourcesInProject} from "../../tasks/project/CreateOpenshiftResourcesInProject";
+import {TaskListMessage} from "../../tasks/TaskListMessage";
+import {TaskRunner} from "../../tasks/TaskRunner";
+import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+
+@EventHandler("Receive GenericProdRequestedEvent events", `
+subscription GenericProdRequestedEvent {
+  GenericProdRequestedEvent {
+    id
+    genericProdRequest{
+      genericProdRequestId
+    }
+  }
+}
+`)
+export class GenericProdRequested implements HandleEvent<any> {
+
+    constructor(public ocService = new OCService(),
+                public gluonService = new GluonService()) {
+    }
+
+    public async handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info(`Ingested GenericProdRequestedEvent event: ${JSON.stringify(event.data)}`);
+
+        const genericProdRequestedEvent = event.data.GenericProdRequestedEvent[0];
+
+        const genericProdRequest = await this.gluonService.prod.generic.getGenericProdRequestById(genericProdRequestedEvent.genericProdRequestId);
+
+        const associatedTeams = await this.gluonService.teams.getTeamsAssociatedToProject(genericProdRequest.project.projectId);
+
+        const qmMessageClient = this.createMessageClient(ctx, associatedTeams);
+
+        try {
+            const project = genericProdRequestedEvent.project;
+
+            const tenant = await this.gluonService.tenants.gluonTenantFromTenantId(project.tenant.tenantId);
+
+            const resources = this.getRequestedProdResources(genericProdRequest);
+
+            const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Creating requested resources in project *${project.name}* production environments started:`,
+                qmMessageClient);
+
+            const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
+
+            for (const openshiftProd of QMConfig.subatomic.openshiftProd) {
+                taskRunner.addTask(new CreateOpenshiftResourcesInProject(project.name, tenant.name, openshiftProd, resources));
+            }
+
+            await taskRunner.execute(ctx);
+
+            return await qmMessageClient.send("Resources successfully created in production environments.");
+        } catch (error) {
+            return await handleQMError(qmMessageClient, error);
+        }
+    }
+
+    private getRequestedProdResources(applicationProdRequest: any) {
+        const resources = {
+            kind: "List",
+            apiVersion: "v1",
+            metadata: {},
+            items: [],
+        };
+        for (const openShiftResource of applicationProdRequest.openShiftResources) {
+            resources.items.push(JSON.parse(openShiftResource.resourceDetails));
+        }
+        return resources;
+    }
+
+    private createMessageClient(ctx: HandlerContext, teams) {
+        const qmMessageClient = new ChannelMessageClient(ctx);
+        for (const team of teams) {
+            qmMessageClient.addDestination(team.slackIdentity.teamChannel);
+        }
+        return qmMessageClient;
+    }
+
+}

--- a/src/gluon/events/project/ProjectProductionEnvironmentsRequested.ts
+++ b/src/gluon/events/project/ProjectProductionEnvironmentsRequested.ts
@@ -40,6 +40,8 @@ export class ProjectProductionEnvironmentsRequested implements HandleEvent<any> 
 
         const associatedTeams = await this.gluonService.teams.getTeamsAssociatedToProject(projectProdRequest.project.projectId);
 
+        logger.info("Associated Teams: " + JSON.stringify(associatedTeams));
+
         const qmMessageClient = this.createMessageClient(ctx, associatedTeams);
 
         try {

--- a/src/gluon/ingesters/genericProdRequested.ts
+++ b/src/gluon/ingesters/genericProdRequested.ts
@@ -1,0 +1,33 @@
+import {Ingester} from "@atomist/automation-client/ingesters";
+
+export const GenericProdRequestedEvent: Ingester = {
+    root_type: "GenericProdRequestedEvent",
+    types: [
+        {
+            kind: "OBJECT",
+            name: "GenericProdRequestedEvent",
+            fields: [
+                {
+                    name: "genericProdRequest",
+                    type: {
+                        kind: "OBJECT",
+                        name: "GenericProdRequest",
+                    },
+                },
+            ],
+        },
+        {
+            kind: "OBJECT",
+            name: "GenericProdRequest",
+            fields: [
+                {
+                    name: "genericProdRequestId",
+                    type: {
+                        kind: "SCALAR",
+                        name: "String",
+                    },
+                },
+            ],
+        },
+    ],
+};

--- a/src/gluon/ingesters/genericProdRequested.ts
+++ b/src/gluon/ingesters/genericProdRequested.ts
@@ -8,19 +8,6 @@ export const GenericProdRequestedEvent: Ingester = {
             name: "GenericProdRequestedEvent",
             fields: [
                 {
-                    name: "genericProdRequest",
-                    type: {
-                        kind: "OBJECT",
-                        name: "GenericProdRequest",
-                    },
-                },
-            ],
-        },
-        {
-            kind: "OBJECT",
-            name: "GenericProdRequest",
-            fields: [
-                {
                     name: "genericProdRequestId",
                     type: {
                         kind: "SCALAR",

--- a/src/gluon/messages/project/GenericProdRequestMessages.ts
+++ b/src/gluon/messages/project/GenericProdRequestMessages.ts
@@ -1,0 +1,46 @@
+import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
+import {SlackMessage, url} from "@atomist/slack-messages";
+import {QMConfig} from "../../../config/QMConfig";
+import {CreateGenericProd} from "../../commands/project/CreateGenericProd";
+import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
+
+export class GenericProdRequestMessages {
+    public confirmProdRequest(prodRequestCommand: CreateGenericProd): SlackMessage {
+
+        const text: string = `By clicking Approve below you confirm that you sign off on the above resources being moved to production. Your user will be logged at the approver for this change.`;
+
+        return {
+            text,
+            attachments: [{
+                fallback: "Please confirm that the above resources should be moved to Prod",
+                footer: `For more information, please read the ${this.docs()}`,
+                thumb_url: "https://raw.githubusercontent.com/absa-subatomic/subatomic-documentation/gh-pages/images/subatomic-logo-colour.png",
+                actions: [
+                    buttonForCommand(
+                        {
+                            text: "Approve Prod Request",
+                            style: "primary",
+                        },
+                        prodRequestCommand,
+                        {
+                            approval: ApprovalEnum.APPROVED,
+                        }),
+                    buttonForCommand(
+                        {
+                            text: "Cancel Prod Request",
+                        },
+                        prodRequestCommand,
+                        {
+                            approval: ApprovalEnum.REJECTED,
+                        }),
+                ],
+            }],
+        };
+    }
+
+    public docs(): string {
+        return `${url(`${QMConfig.subatomic.docs.baseUrl}/`,
+            "documentation")}`;
+    }
+
+}

--- a/src/gluon/services/gluon/GenericProdRequestService.ts
+++ b/src/gluon/services/gluon/GenericProdRequestService.ts
@@ -12,7 +12,7 @@ export class GenericProdRequestService {
 
     public async createGenericProdRequest(genericProdRequestDetails: any, rawResult: boolean = false): Promise<any> {
         logger.debug(`Trying to create generic prod request.`);
-        const prodRequestResult = await this.axiosInstance.post(`${QMConfig.subatomic.gluon.baseUrl}/genericProdRequest`, genericProdRequestDetails);
+        const prodRequestResult = await this.axiosInstance.post(`${QMConfig.subatomic.gluon.baseUrl}/genericProdRequests`, genericProdRequestDetails);
         if (rawResult) {
             return prodRequestResult;
         }
@@ -27,7 +27,7 @@ export class GenericProdRequestService {
 
     public async getGenericProdRequestById(genericProdRequestId: string, rawResult: boolean = false): Promise<any> {
         logger.debug(`Trying to create generic prod request. genericProdRequestId: ${genericProdRequestId}`);
-        const prodRequestResult = await this.axiosInstance.get(`${QMConfig.subatomic.gluon.baseUrl}/genericProdRequest/${genericProdRequestId}`);
+        const prodRequestResult = await this.axiosInstance.get(`${QMConfig.subatomic.gluon.baseUrl}/genericProdRequests/${genericProdRequestId}`);
         if (rawResult) {
             return prodRequestResult;
         }

--- a/src/gluon/services/gluon/GenericProdRequestService.ts
+++ b/src/gluon/services/gluon/GenericProdRequestService.ts
@@ -1,0 +1,42 @@
+import {logger} from "@atomist/automation-client";
+import {inspect} from "util";
+import {QMConfig} from "../../../config/QMConfig";
+import {AwaitAxios} from "../../../http/AwaitAxios";
+import {isSuccessCode} from "../../../http/Http";
+import {QMError} from "../../util/shared/Error";
+
+export class GenericProdRequestService {
+
+    constructor(public axiosInstance = new AwaitAxios()) {
+    }
+
+    public async createGenericProdRequest(genericProdRequestDetails: any, rawResult: boolean = false): Promise<any> {
+        logger.debug(`Trying to create generic prod request.`);
+        const prodRequestResult = await this.axiosInstance.post(`${QMConfig.subatomic.gluon.baseUrl}/genericProdRequest`, genericProdRequestDetails);
+        if (rawResult) {
+            return prodRequestResult;
+        }
+
+        if (!isSuccessCode(prodRequestResult.status)) {
+            logger.error(`Request to create generic prod request failed: ${inspect(prodRequestResult)}`);
+            throw new QMError("Unable to create the prod request. Please make sure that you are member of a team associated to the application");
+        }
+
+        return prodRequestResult.data;
+    }
+
+    public async getGenericProdRequestById(genericProdRequestId: string, rawResult: boolean = false): Promise<any> {
+        logger.debug(`Trying to create generic prod request. genericProdRequestId: ${genericProdRequestId}`);
+        const prodRequestResult = await this.axiosInstance.get(`${QMConfig.subatomic.gluon.baseUrl}/genericProdRequest/${genericProdRequestId}`);
+        if (rawResult) {
+            return prodRequestResult;
+        }
+
+        if (!isSuccessCode(prodRequestResult.status)) {
+            logger.error(`Request to find generic prod request failed: ${inspect(prodRequestResult)}`);
+            throw new QMError("Unable to find the prod request details for raised request. Please make sure the request exists or contact your Subatomic administrator.");
+        }
+
+        return prodRequestResult.data;
+    }
+}

--- a/src/gluon/services/gluon/GluonProdService.ts
+++ b/src/gluon/services/gluon/GluonProdService.ts
@@ -1,8 +1,10 @@
 import {ApplicationProdRequestService} from "./ApplicationProdRequestService";
+import {GenericProdRequestService} from "./GenericProdRequestService";
 import {ProjectProdRequestService} from "./ProjectProdRequestService";
 
 export class GluonProdService {
     constructor(public application = new ApplicationProdRequestService(),
-                public project = new ProjectProdRequestService()) {
+                public project = new ProjectProdRequestService(),
+                public generic = new GenericProdRequestService()) {
     }
 }

--- a/src/gluon/services/projects/GenericOpenshiftResourceService.ts
+++ b/src/gluon/services/projects/GenericOpenshiftResourceService.ts
@@ -1,0 +1,56 @@
+export class GenericOpenshiftResourceService {
+
+    public async getAllPromotableResources(resources) {
+
+        this.cleanDeploymentConfigs(resources);
+        this.cleanImageStreams(resources);
+        this.cleanRoutes(resources);
+        this.cleanPVCs(resources);
+        this.removeUnwantedResources(resources);
+
+        return resources;
+    }
+
+    private cleanPVCs(allResources) {
+        for (const resource of allResources.items) {
+            if (resource.kind === "PersistentVolumeClaim") {
+                delete resource.spec.volumeName;
+                delete resource.metadata.annotations;
+            }
+        }
+    }
+
+    private cleanDeploymentConfigs(allResources) {
+        for (const resource of allResources.items) {
+            if (resource.kind === "DeploymentConfig") {
+                resource.spec.replicas = 0;
+            }
+        }
+    }
+
+    private cleanImageStreams(allResources) {
+        for (const resource of allResources.items) {
+            if (resource.kind === "ImageStream") {
+                resource.spec.tags = [];
+            }
+        }
+    }
+
+    private cleanRoutes(allResources) {
+        for (const resource of allResources.items) {
+            if (resource.kind === "Route") {
+                delete resource.spec.host;
+                resource.status = {};
+            }
+        }
+    }
+
+    private removeUnwantedResources(allResources) {
+        for (let i = allResources.items.length - 1; i >= 0; i--) {
+            const resource = allResources.items;
+            if (resource.kind === "Pod" || resource.kind === "ReplicationController") {
+                allResources.items.splice(i, 1);
+            }
+        }
+    }
+}

--- a/src/gluon/util/openshift/Helpers.ts
+++ b/src/gluon/util/openshift/Helpers.ts
@@ -1,0 +1,15 @@
+import {OpenshiftProjectEnvironment} from "../../../config/OpenShiftConfig";
+import {QMConfig} from "../../../config/QMConfig";
+
+export function getHighestPreProdEnvironment(): OpenshiftProjectEnvironment {
+    const nEnvironments = QMConfig.subatomic.openshiftNonProd.defaultEnvironments.length;
+    return QMConfig.subatomic.openshiftNonProd.defaultEnvironments[nEnvironments - 1];
+}
+
+export function getResourceDisplayMessage(allResources) {
+    let text = "Found the following resources:\n";
+    for (const resource of allResources.items) {
+        text += `\t*${resource.kind}:* ${resource.metadata.name}\n`;
+    }
+    return text;
+}


### PR DESCRIPTION
Implemented generic prod requests. This will run an oc get all command on the highest non prod environment, and will recreate all the resources that it finds in the associated prod environments.

This commit includes a couple of fixes related to the project prod requests too.

This closes #335 