### PR TITLE
Dont use proxy for openshift api calls.

### DIFF
--- a/src/openshift/api/base/OpenShiftApiElement.ts
+++ b/src/openshift/api/base/OpenShiftApiElement.ts
@@ -18,6 +18,7 @@ export abstract class OpenShiftApiElement {
             httpsAgent: new https.Agent({
                 rejectUnauthorized: false,
             }),
+            proxy: false,
         });
         instance.defaults.headers.common.Authorization = "bearer " + this.openShiftConfig.auth.token;
         return new AwaitAxios(instance);
@@ -33,6 +34,7 @@ export abstract class OpenShiftApiElement {
             httpsAgent: new https.Agent({
                 rejectUnauthorized: false,
             }),
+            proxy: false,
         });
         instance.defaults.headers.common.Authorization = "bearer " + this.openShiftConfig.auth.token;
         return new AwaitAxios(instance);


### PR DESCRIPTION
When behind proxy, the api calls timeout. Removed proxy just like is done for the Jenkins axios calls.