### PR TITLE
Added commands to change member permissions

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -26,6 +26,7 @@ import {
 import {ReRunProjectProdRequest} from "./gluon/commands/project/ReRunProjectProdRequest";
 import {UpdateProjectProdRequest} from "./gluon/commands/project/UpdateProjectProdRequest";
 import {AddMemberToTeam} from "./gluon/commands/team/AddMemberToTeam";
+import {AddOwnerToTeam} from "./gluon/commands/team/AddOwnerToTeam";
 import {CreateMembershipRequestToTeam} from "./gluon/commands/team/CreateMembershipRequestToTeam";
 import {CreateTeam} from "./gluon/commands/team/CreateTeam";
 import {NewDevOpsEnvironment} from "./gluon/commands/team/DevOpsEnvironment";
@@ -111,6 +112,7 @@ export const configuration: any = {
         AddSlackDetails,
         JoinTeam,
         AddMemberToTeam,
+        AddOwnerToTeam,
         AssociateTeam,
         CreateTeam,
         CreateProject,

--- a/src/gluon/commands/team/AddMemberToTeam.ts
+++ b/src/gluon/commands/team/AddMemberToTeam.ts
@@ -1,6 +1,5 @@
 import {
     CommandHandler,
-    HandleCommand,
     HandlerContext,
     HandlerResult,
     MappedParameter,
@@ -9,15 +8,28 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {QMConfig} from "../../../config/QMConfig";
+import {GluonService} from "../../services/gluon/GluonService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
 import {AddMemberToTeamTask} from "../../tasks/team/AddMemberToTeamTask";
 import {MemberRole} from "../../util/member/Members";
+import {
+    GluonTeamNameSetter,
+    setGluonTeamName,
+} from "../../util/recursiveparam/GluonParameterSetters";
+import {
+    RecursiveParameter,
+    RecursiveParameterRequestCommand,
+} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
 
-@CommandHandler("Add a member as an owner to a team", QMConfig.subatomic.commandPrefix + " add team member")
+@CommandHandler("Add a member to a team", QMConfig.subatomic.commandPrefix + " add team member")
 @Tags("subatomic", "team", "member")
-export class AddMemberToTeam implements HandleCommand<HandlerResult> {
+export class AddMemberToTeam extends RecursiveParameterRequestCommand implements GluonTeamNameSetter {
+
+    private static RecursiveKeys = {
+        teamName: "TEAM_NAME",
+    };
 
     @MappedParameter(MappedParameters.SlackUserName)
     public screenName: string;
@@ -36,14 +48,28 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
     })
     public slackName: string;
 
-    public async handle(ctx: HandlerContext): Promise<HandlerResult> {
+    @RecursiveParameter({
+        recursiveKey: AddMemberToTeam.RecursiveKeys.teamName,
+        selectionMessage: "Please select a team you would like to add a member to",
+    })
+    public teamName: string;
+
+    constructor(public gluonService = new GluonService()) {
+        super();
+    }
+
+    protected configureParameterSetters() {
+        this.addRecursiveSetter(AddMemberToTeam.RecursiveKeys.teamName, setGluonTeamName);
+    }
+
+    protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Adding member to team started:`,
                 new ResponderMessageClient(ctx));
 
             const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
 
-            taskRunner.addTask(new AddMemberToTeamTask(this.slackName, this.teamChannel, this.screenName, MemberRole.MEMBER));
+            taskRunner.addTask(new AddMemberToTeamTask(this.slackName, this.screenName, this.teamName, MemberRole.member));
 
             await taskRunner.execute(ctx);
         } catch (error) {

--- a/src/gluon/commands/team/AddOwnerToTeam.ts
+++ b/src/gluon/commands/team/AddOwnerToTeam.ts
@@ -1,6 +1,5 @@
 import {
     CommandHandler,
-    HandleCommand,
     HandlerContext,
     HandlerResult,
     MappedParameter,
@@ -9,15 +8,28 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {QMConfig} from "../../../config/QMConfig";
+import {GluonService} from "../../services/gluon/GluonService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
 import {AddMemberToTeamTask} from "../../tasks/team/AddMemberToTeamTask";
 import {MemberRole} from "../../util/member/Members";
+import {
+    GluonTeamNameSetter,
+    setGluonTeamName,
+} from "../../util/recursiveparam/GluonParameterSetters";
+import {
+    RecursiveParameter,
+    RecursiveParameterRequestCommand,
+} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
 
 @CommandHandler("Add a member as an owner to a team", QMConfig.subatomic.commandPrefix + " add team owner")
 @Tags("subatomic", "team", "member")
-export class AddOwnerToTeam implements HandleCommand<HandlerResult> {
+export class AddOwnerToTeam extends RecursiveParameterRequestCommand implements GluonTeamNameSetter {
+
+    private static RecursiveKeys = {
+        teamName: "TEAM_NAME",
+    };
 
     @MappedParameter(MappedParameters.SlackUserName)
     public screenName: string;
@@ -36,14 +48,28 @@ export class AddOwnerToTeam implements HandleCommand<HandlerResult> {
     })
     public slackName: string;
 
-    public async handle(ctx: HandlerContext): Promise<HandlerResult> {
+    @RecursiveParameter({
+        recursiveKey: AddOwnerToTeam.RecursiveKeys.teamName,
+        selectionMessage: "Please select a team you would like to add a owner to",
+    })
+    public teamName: string;
+
+    constructor(public gluonService = new GluonService()) {
+        super();
+    }
+
+    protected configureParameterSetters() {
+        this.addRecursiveSetter(AddOwnerToTeam.RecursiveKeys.teamName, setGluonTeamName);
+    }
+
+    protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Adding member to team started:`,
                 new ResponderMessageClient(ctx));
 
             const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
 
-            taskRunner.addTask(new AddMemberToTeamTask(this.slackName, this.teamChannel, this.screenName, MemberRole.OWNER));
+            taskRunner.addTask(new AddMemberToTeamTask(this.slackName, this.screenName, this.teamName, MemberRole.owner));
 
             await taskRunner.execute(ctx);
         } catch (error) {

--- a/src/gluon/commands/team/AddOwnerToTeam.ts
+++ b/src/gluon/commands/team/AddOwnerToTeam.ts
@@ -15,9 +15,9 @@ import {AddMemberToTeamTask} from "../../tasks/team/AddMemberToTeamTask";
 import {MemberRole} from "../../util/member/Members";
 import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
 
-@CommandHandler("Add a member as an owner to a team", QMConfig.subatomic.commandPrefix + " add team member")
+@CommandHandler("Add a member as an owner to a team", QMConfig.subatomic.commandPrefix + " add team owner")
 @Tags("subatomic", "team", "member")
-export class AddMemberToTeam implements HandleCommand<HandlerResult> {
+export class AddOwnerToTeam implements HandleCommand<HandlerResult> {
 
     @MappedParameter(MappedParameters.SlackUserName)
     public screenName: string;
@@ -32,7 +32,7 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
     public teamChannel: string;
 
     @Parameter({
-        description: "slack name (@User.Name) of the member to make a member",
+        description: "slack name (@User.Name) of the member to make an owner",
     })
     public slackName: string;
 
@@ -43,7 +43,7 @@ export class AddMemberToTeam implements HandleCommand<HandlerResult> {
 
             const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
 
-            taskRunner.addTask(new AddMemberToTeamTask(this.slackName, this.teamChannel, this.screenName, MemberRole.MEMBER));
+            taskRunner.addTask(new AddMemberToTeamTask(this.slackName, this.teamChannel, this.screenName, MemberRole.OWNER));
 
             await taskRunner.execute(ctx);
         } catch (error) {

--- a/src/gluon/messages/team/AddMemberToTeamMessages.ts
+++ b/src/gluon/messages/team/AddMemberToTeamMessages.ts
@@ -25,21 +25,6 @@ Click the button below to become familiar with the projects this team is involve
         };
     }
 
-    public alertTeamDoesNotExist(teamChannel: string): SlackMessage {
-        return {
-            text: "This is not a team channel or not a team channel you belong to",
-            attachments: [{
-                text: `
-This channel (*${teamChannel}*) is not a team channel for a team that you belong to.
-You can only invite a new member to your team from a team channel that you belong to. Please retry this in one of those team channels.
-                                                              `,
-                fallback: "This is not a team channel or not a team channel you belong to",
-                color: "#D94649",
-                mrkdwn_in: ["text"],
-            }],
-        };
-    }
-
     private docs(extension): string {
         return `${url(`${QMConfig.subatomic.docs.baseUrl}/quantum-mechanic/command-reference#${extension}`,
             "documentation")}`;

--- a/src/gluon/services/team/AddMemberToTeamService.ts
+++ b/src/gluon/services/team/AddMemberToTeamService.ts
@@ -8,6 +8,7 @@ import {isSuccessCode} from "../../../http/Http";
 import {OnboardMember} from "../../commands/member/OnboardMember";
 import {AddMemberToTeam} from "../../commands/team/AddMemberToTeam";
 import {AddMemberToTeamMessages} from "../../messages/team/AddMemberToTeamMessages";
+import {MemberRole} from "../../util/member/Members";
 import {QMError} from "../../util/shared/Error";
 import {
     getTeamSlackChannel,
@@ -83,11 +84,31 @@ They have been sent a request to onboard, once they've successfully onboarded yo
         }
     }
 
-    public async addUserToGluonTeam(newMemberId: string, actioningMemberId: string, gluonTeamUrl: string) {
+    public async addUserToGluonTeam(newMemberId: string, actioningMemberId: string, gluonTeamUrl: string, memberRole: MemberRole = MemberRole.MEMBER) {
         logger.info(`Adding member [${newMemberId}] to team ${gluonTeamUrl}`);
 
         const splitLink = gluonTeamUrl.split("/");
         const gluonTeamId = splitLink[splitLink.length - 1];
+
+        const memberDetails = {
+            members: [],
+            owners: [],
+            createdBy: actioningMemberId,
+        };
+
+        if (memberRole === MemberRole.OWNER) {
+            memberDetails.owners.push(
+                {
+                    memberId: newMemberId,
+                },
+            );
+        } else {
+            memberDetails.members.push(
+                {
+                    memberId: newMemberId,
+                },
+            );
+        }
 
         const updateTeamResult = await this.gluonService.teams.addMemberToTeam(gluonTeamId,
             {

--- a/src/gluon/services/team/AddMemberToTeamService.ts
+++ b/src/gluon/services/team/AddMemberToTeamService.ts
@@ -2,7 +2,7 @@ import {HandlerContext, logger} from "@atomist/automation-client";
 import {buttonForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/handlers/command/slack/AssociateRepo";
 import {SlackMessage, url} from "@atomist/slack-messages";
-import * as _ from "lodash";
+import {inspect} from "util";
 import {QMConfig} from "../../../config/QMConfig";
 import {isSuccessCode} from "../../../http/Http";
 import {OnboardMember} from "../../commands/member/OnboardMember";
@@ -10,10 +10,7 @@ import {AddMemberToTeam} from "../../commands/team/AddMemberToTeam";
 import {AddMemberToTeamMessages} from "../../messages/team/AddMemberToTeamMessages";
 import {MemberRole} from "../../util/member/Members";
 import {QMError} from "../../util/shared/Error";
-import {
-    getTeamSlackChannel,
-    loadChannelIdByChannelName,
-} from "../../util/team/Teams";
+import {loadChannelIdByChannelName} from "../../util/team/Teams";
 import {GluonService} from "../gluon/GluonService";
 
 export class AddMemberToTeamService {
@@ -23,11 +20,9 @@ export class AddMemberToTeamService {
     constructor(private gluonService = new GluonService()) {
     }
 
-    public async getNewMember(ctx: HandlerContext, chatId: string, teamChannel: string) {
+    public async getNewMemberGluonDetails(ctx: HandlerContext, chatId: string, teamChannel: string) {
         try {
-            const newMember = await this.gluonService.members.gluonMemberFromScreenName(chatId);
-
-            return this.partOfTeam(newMember, teamChannel);
+            return await this.gluonService.members.gluonMemberFromScreenName(chatId);
         } catch (error) {
             const isQMError = error instanceof QMError;
             if (!isQMError || (isQMError && error.message === `${chatId} is already a member of this team.`)) {
@@ -84,11 +79,8 @@ They have been sent a request to onboard, once they've successfully onboarded yo
         }
     }
 
-    public async addUserToGluonTeam(newMemberId: string, actioningMemberId: string, gluonTeamUrl: string, memberRole: MemberRole = MemberRole.MEMBER) {
-        logger.info(`Adding member [${newMemberId}] to team ${gluonTeamUrl}`);
-
-        const splitLink = gluonTeamUrl.split("/");
-        const gluonTeamId = splitLink[splitLink.length - 1];
+    public async addUserToGluonTeam(newMemberId: string, actioningMemberId: string, gluonTeamId: string, memberRole: MemberRole = MemberRole.member) {
+        logger.info(`Adding member [${newMemberId}] to team ${gluonTeamId}`);
 
         const memberDetails = {
             members: [],
@@ -96,7 +88,7 @@ They have been sent a request to onboard, once they've successfully onboarded yo
             createdBy: actioningMemberId,
         };
 
-        if (memberRole === MemberRole.OWNER) {
+        if (memberRole === MemberRole.owner) {
             memberDetails.owners.push(
                 {
                     memberId: newMemberId,
@@ -111,24 +103,28 @@ They have been sent a request to onboard, once they've successfully onboarded yo
         }
 
         const updateTeamResult = await this.gluonService.teams.addMemberToTeam(gluonTeamId,
-            {
-                members: [{
-                    memberId: newMemberId,
-                }],
-                createdBy: actioningMemberId,
-            });
+            memberDetails);
 
         if (!isSuccessCode(updateTeamResult.status)) {
+            logger.error(`Failed to add member to team: ${inspect(updateTeamResult)}`);
             throw new QMError(`Failed to add member to the team. Server side failure.`);
         }
     }
 
-    private async partOfTeam(newMember, teamChannel: string) {
-        if (!_.isEmpty(_.find(newMember.teams,
-            (team: any) => getTeamSlackChannel(team) === teamChannel))) {
-            throw new QMError(`${newMember.slack.screenName} is already a member of this team.`);
+    public verifyAddMemberRequest(newMember: { memberId: string, slack: { screenName: string } }, team: { owners: Array<{ memberId: string }>, members: Array<{ memberId: string }> }, memberRole: MemberRole) {
+        if (memberRole === MemberRole.owner) {
+            for (const owner of team.owners) {
+                if (owner.memberId === newMember.memberId) {
+                    throw new QMError(`${newMember.slack.screenName} is already an owner of this team.`);
+                }
+            }
+        } else {
+            for (const member of team.members) {
+                if (member.memberId === newMember.memberId) {
+                    throw new QMError(`${newMember.slack.screenName} is already a member of this team.`);
+                }
+            }
         }
-        return newMember;
     }
 
     private async onboardMessage(ctx, chatId: string, teamChannel: string) {

--- a/src/gluon/tasks/team/AddMemberToTeamTask.ts
+++ b/src/gluon/tasks/team/AddMemberToTeamTask.ts
@@ -1,0 +1,70 @@
+import {HandlerContext, logger} from "@atomist/automation-client";
+import * as _ from "lodash";
+import {AddMemberToTeamMessages} from "../../messages/team/AddMemberToTeamMessages";
+import {GluonService} from "../../services/gluon/GluonService";
+import {AddMemberToTeamService} from "../../services/team/AddMemberToTeamService";
+import {
+    getScreenName,
+    loadScreenNameByUserId,
+    MemberRole,
+} from "../../util/member/Members";
+import {Task} from "../Task";
+import {TaskListMessage} from "../TaskListMessage";
+
+export class AddMemberToTeamTask extends Task {
+
+    private addMemberToTeamMessages = new AddMemberToTeamMessages();
+
+    private readonly TASK_GATHER_REQUEST_DETAILS = TaskListMessage.createUniqueTaskName("GatherRequestDetails");
+    private readonly TASK_ADD_USER_TO_TEAM = TaskListMessage.createUniqueTaskName("AddUserToTeam");
+
+    constructor(private slackName: string,
+                private teamChannel: string,
+                private screenName: string,
+                private memberRole: MemberRole,
+                private addMemberToTeamService = new AddMemberToTeamService(),
+                private gluonService = new GluonService()) {
+        super();
+    }
+
+    protected configureTaskListMessage(taskListMessage: TaskListMessage) {
+        taskListMessage.addTask(this.TASK_GATHER_REQUEST_DETAILS, "Gather required membership request details");
+        taskListMessage.addTask(this.TASK_ADD_USER_TO_TEAM, "Add user to team with role: " + this.memberRole.toString());
+    }
+
+    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+
+        logger.info(`Adding member [${this.slackName}] to team: ${this.teamChannel}`);
+
+        const screenName = getScreenName(this.slackName);
+
+        const chatId = await loadScreenNameByUserId(ctx, screenName);
+
+        logger.info(`Got ChatId: ${chatId}`);
+
+        const newMember = await this.addMemberToTeamService.getNewMember(ctx, chatId, this.teamChannel);
+
+        logger.info(`Gluon member found: ${JSON.stringify(newMember)}`);
+
+        logger.info(`Getting teams that ${this.screenName} (you) are a part of...`);
+
+        const actioningMember = await this.gluonService.members.gluonMemberFromScreenName(this.screenName);
+
+        logger.info(`Got member's teams you belong to: ${JSON.stringify(actioningMember)}`);
+
+        const teamSlackChannel = _.find(actioningMember.teams,
+            (team: any) => team.slack.teamChannel === this.teamChannel);
+
+        await this.taskListMessage.succeedTask(this.TASK_GATHER_REQUEST_DETAILS);
+
+        if (!_.isEmpty(teamSlackChannel)) {
+            await this.addMemberToTeamService.addUserToGluonTeam(newMember.memberId, actioningMember.memberId, teamSlackChannel._links.self.href, this.memberRole);
+            await this.taskListMessage.succeedTask(this.TASK_ADD_USER_TO_TEAM);
+        } else {
+            await ctx.messageClient.respond(this.addMemberToTeamMessages.alertTeamDoesNotExist(this.teamChannel));
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -35,3 +35,7 @@ export async function loadScreenNameByUserId(ctx: HandlerContext, userId: string
 export interface QMMember {
     domainUsername: string;
 }
+
+export enum MemberRole {
+    OWNER, MEMBER,
+}

--- a/src/gluon/util/member/Members.ts
+++ b/src/gluon/util/member/Members.ts
@@ -37,5 +37,6 @@ export interface QMMember {
 }
 
 export enum MemberRole {
-    OWNER, MEMBER,
+    owner = "Owner",
+    member = "Member",
 }

--- a/test/gluon/services/team/AddMemberToTeamServiceTest.ts
+++ b/test/gluon/services/team/AddMemberToTeamServiceTest.ts
@@ -1,49 +1,15 @@
 import assert = require("power-assert");
-import {anything, instance, mock, verify, when} from "ts-mockito";
+import {anything, instance, mock, when} from "ts-mockito";
 import {GluonService} from "../../../../src/gluon/services/gluon/GluonService";
 import {MemberService} from "../../../../src/gluon/services/gluon/MemberService";
 import {TeamService} from "../../../../src/gluon/services/gluon/TeamService";
 import {AddMemberToTeamService} from "../../../../src/gluon/services/team/AddMemberToTeamService";
+import {MemberRole} from "../../../../src/gluon/util/member/Members";
 import {QMError} from "../../../../src/gluon/util/shared/Error";
 import {TestGraphClient} from "../../TestGraphClient";
 import {TestMessageClient} from "../../TestMessageClient";
 
 describe("AddMemberToTeamService getNewMemberGluonDetails", () => {
-    it("should return error that member is part of team already", async () => {
-        const mockedMemberService = mock(MemberService);
-        when(mockedMemberService.gluonMemberFromScreenName("Dex")).thenReturn(Promise.resolve({
-            id: "User1",
-            teams: [
-                {
-                    slack: {
-                        teamChannel: "Channel1",
-                    },
-                },
-            ],
-            slack: {
-                screenName: "Dex",
-            },
-        }));
-        const gluonService = new GluonService(undefined, undefined, instance(mockedMemberService));
-        const service = new AddMemberToTeamService(gluonService);
-        const fakeContext = {
-            teamId: "TEST",
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-        };
-
-        let errorThrown: QMError = null;
-        try {
-            await service.getNewMemberGluonDetails(fakeContext, "Dex", "Channel1");
-        } catch (error) {
-            errorThrown = error;
-        }
-
-        assert.equal(errorThrown.message, `Dex is already a member of this team.`);
-
-    });
-
     it("should return member details", async () => {
         const mockedMemberService = mock(MemberService);
         when(mockedMemberService.gluonMemberFromScreenName("Dex")).thenReturn(Promise.resolve({
@@ -86,26 +52,13 @@ describe("AddMemberToTeamService addUserToGluonTeam", () => {
 
         let errorThrown: QMError = null;
         try {
-            await service.addUserToGluonTeam("User1", "User2", "http://gluon/teams/team1");
+            await service.addUserToGluonTeam("User1", "User2", "team1");
         } catch (error) {
             errorThrown = error;
         }
 
         assert.equal(errorThrown.message, `Failed to add member to the team. Server side failure.`);
 
-    });
-
-    it("should extract the correct gluon team id from url", async () => {
-        const mockedTeamService = mock(TeamService);
-        when(mockedTeamService.addMemberToTeam("team1", anything())).thenReturn(Promise.resolve({
-            status: 200,
-        }));
-        const gluonService = new GluonService(undefined, instance(mockedTeamService));
-        const service = new AddMemberToTeamService(gluonService);
-
-        await service.addUserToGluonTeam("User1", "User2", "http://gluon/teams/team1");
-
-        verify(mockedTeamService.addMemberToTeam("team1", anything())).called();
     });
 
     it("should successfully execute gluon add", async () => {
@@ -118,7 +71,7 @@ describe("AddMemberToTeamService addUserToGluonTeam", () => {
 
         let errorThrown: boolean = false;
         try {
-            await service.addUserToGluonTeam("User1", "User2", "http://gluon/teams/team1");
+            await service.addUserToGluonTeam("User1", "User2", "team1");
         } catch (error) {
             errorThrown = true;
         }
@@ -180,5 +133,123 @@ describe("AddMemberToTeamService inviteUserToSlackChannel", () => {
 
         assert.equal(fakeContext.messageClient.textMsg[0].text, "Welcome to the team *Jude*!");
 
+    });
+});
+
+describe("AddMemberToTeamService verifyAddMemberRequest", () => {
+    it("should throw error for existing owner", async () => {
+
+        const service = new AddMemberToTeamService();
+
+        const newMember = {
+            memberId: "member1",
+            slack: {
+                screenName: "Craig",
+            },
+        };
+
+        const team = {
+            owners: [
+                {memberId: "member1"},
+            ],
+            members: [],
+        };
+
+        let errorThrown: QMError = null;
+        try {
+            await service.verifyAddMemberRequest(newMember,
+                team,
+                MemberRole.owner);
+        } catch (error) {
+            errorThrown = error;
+        }
+
+        assert.equal(errorThrown.message, "Craig is already an owner of this team.");
+    });
+
+    it("should throw error for existing member", async () => {
+
+        const service = new AddMemberToTeamService();
+
+        const newMember = {
+            memberId: "member1",
+            slack: {
+                screenName: "Craig",
+            },
+        };
+
+        const team = {
+            owners: [],
+            members: [
+                {memberId: "member1"},
+            ],
+        };
+
+        let errorThrown: QMError = null;
+        try {
+            await service.verifyAddMemberRequest(newMember,
+                team,
+                MemberRole.member);
+        } catch (error) {
+            errorThrown = error;
+        }
+
+        assert.equal(errorThrown.message, "Craig is already a member of this team.");
+    });
+
+    it("should allow an owner to be promoted from member", async () => {
+
+        const service = new AddMemberToTeamService();
+
+        const newMember = {
+            memberId: "member1",
+            slack: {
+                screenName: "Craig",
+            },
+        };
+
+        const team = {
+            owners: [],
+            members: [{memberId: "member1"}],
+        };
+
+        let errorThrown: boolean = false;
+        try {
+            await service.verifyAddMemberRequest(newMember,
+                team,
+                MemberRole.owner);
+        } catch (error) {
+            errorThrown = true;
+        }
+
+        assert.equal(errorThrown, false);
+    });
+
+    it("should allow a member to be demoted from owner", async () => {
+
+        const service = new AddMemberToTeamService();
+
+        const newMember = {
+            memberId: "member1",
+            slack: {
+                screenName: "Craig",
+            },
+        };
+
+        const team = {
+            owners: [{memberId: "member1"}],
+            members: [],
+        };
+
+        let errorThrown: boolean = false;
+        try {
+            await service.verifyAddMemberRequest(newMember,
+                team,
+                MemberRole.member);
+        } catch (error) {
+            errorThrown = true;
+        }
+
+        assert.equal(errorThrown, false);
     });
 });

--- a/test/gluon/services/team/AddMemberToTeamServiceTest.ts
+++ b/test/gluon/services/team/AddMemberToTeamServiceTest.ts
@@ -8,7 +8,7 @@ import {QMError} from "../../../../src/gluon/util/shared/Error";
 import {TestGraphClient} from "../../TestGraphClient";
 import {TestMessageClient} from "../../TestMessageClient";
 
-describe("AddMemberToTeamService getNewMember", () => {
+describe("AddMemberToTeamService getNewMemberGluonDetails", () => {
     it("should return error that member is part of team already", async () => {
         const mockedMemberService = mock(MemberService);
         when(mockedMemberService.gluonMemberFromScreenName("Dex")).thenReturn(Promise.resolve({
@@ -35,7 +35,7 @@ describe("AddMemberToTeamService getNewMember", () => {
 
         let errorThrown: QMError = null;
         try {
-            await service.getNewMember(fakeContext, "Dex", "Channel1");
+            await service.getNewMemberGluonDetails(fakeContext, "Dex", "Channel1");
         } catch (error) {
             errorThrown = error;
         }
@@ -68,7 +68,7 @@ describe("AddMemberToTeamService getNewMember", () => {
             messageClient: new TestMessageClient(),
         };
 
-        const result = await service.getNewMember(fakeContext, "Dex", "Channel2");
+        const result = await service.getNewMemberGluonDetails(fakeContext, "Dex", "Channel2");
 
         assert.equal(result.id, "User1");
 


### PR DESCRIPTION
Owners of teams can now:
- Add new users as owners
- Promote members to owners
- Demote owners to members

Includes moving the add member to team command to being task oriented then reusing the logic between the AddMemberToTeam and AddOwnerToTeam. The general command has also been updated since the way it ran was really convoluted and outdated.

Closes #388 