### PR TITLE
Qm creates view role on users

### DIFF
--- a/src/gluon/events/team/MembersAddedToTeam.ts
+++ b/src/gluon/events/team/MembersAddedToTeam.ts
@@ -14,7 +14,7 @@ import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
 import {AddMemberToTeamService} from "../../services/team/AddMemberToTeamService";
-import {getProjectDisplayName, getProjectId} from "../../util/project/Project";
+import {getProjectId} from "../../util/project/Project";
 import {
     ChannelMessageClient,
     handleQMError,

--- a/src/gluon/events/team/MembersAddedToTeam.ts
+++ b/src/gluon/events/team/MembersAddedToTeam.ts
@@ -14,7 +14,7 @@ import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
 import {AddMemberToTeamService} from "../../services/team/AddMemberToTeamService";
-import {getProjectDisplayName} from "../../util/project/Project";
+import {getProjectDisplayName, getProjectId} from "../../util/project/Project";
 import {
     ChannelMessageClient,
     handleQMError,
@@ -136,7 +136,7 @@ export class MembersAddedToTeam implements HandleEvent<any> {
                 // Add to openshift environments
                 for (const environment of QMConfig.subatomic.openshiftNonProd.defaultEnvironments) {
                     const tenant = await this.gluonService.tenants.gluonTenantFromTenantId(project.owningTenant);
-                    const projectId = getProjectDisplayName(tenant.name, project.name, environment.id);
+                    const projectId = getProjectId(tenant.name, project.name, environment.id);
                     await this.ocService.addTeamMembershipPermissionsToProject(projectId, membersAddedToTeamEvent);
                 }
             }

--- a/src/gluon/services/openshift/OCService.ts
+++ b/src/gluon/services/openshift/OCService.ts
@@ -465,7 +465,7 @@ export class OCService {
         await team.members.map(async member => {
             const memberUsername = /[^\\]*$/.exec(member.domainUsername)[0];
             await logger.info(`Adding role to project [${projectId}] and member [${member.domainUsername}]: ${memberUsername}`);
-            return await this.openShiftApi.policy.addRoleToUser(memberUsername, "view", projectId);
+            return await this.openShiftApi.policy.addRoleToUser(memberUsername, "edit", projectId);
         });
     }
 


### PR DESCRIPTION
Changed 'view' to 'edit' on project memberships for new team members in OpenShift and fixed a bug that was using the display name instead of the correct project id.