### PR TITLE
Add Python application type

### DIFF
--- a/resources/templates/jenkins/jenkinsfile-repo/nodejs.groovy
+++ b/resources/templates/jenkins/jenkinsfile-repo/nodejs.groovy
@@ -6,6 +6,8 @@
  * Type          | ID                | Description
  * Secret text   | devops-project    | The OpenShift project Id of the DevOps project that this Jenkins instance is running in
  * Secret text   | dev-project       | The OpenShift project Id of the project's development environment
+ * Secret text   | sit-project       | The OpenShift project Id of the project's sit environment
+ * Secret text   | uat-project       | The OpenShift project Id of the project's uat environment
  *
  */
 
@@ -60,6 +62,8 @@ def getSCMInformation() {
 node('nodejs') {
     def teamDevOpsProject
     def projectDevProject
+    def projectSitProject
+    def projectUatProject
 
     withCredentials([
             string(credentialsId: 'devops-project', variable: 'DEVOPS_PROJECT_ID'),

--- a/resources/templates/jenkins/jenkinsfile-repo/python36.groovy
+++ b/resources/templates/jenkins/jenkinsfile-repo/python36.groovy
@@ -1,0 +1,153 @@
+/**
+ * Jenkins pipeline to build an application with the GitHub flow in mind (https://guides.github.com/introduction/flow/).
+ *
+ * This pipeline requires the following credentials:
+ * ---
+ * Type          | ID                | Description
+ * Secret text   | devops-project    | The OpenShift project Id of the DevOps project that this Jenkins instance is running in
+ * Secret text   | dev-project       | The OpenShift project Id of the project's development environment
+ * Secret text   | sit-project       | The OpenShift project Id of the project's sit environment
+ * Secret text   | uat-project       | The OpenShift project Id of the project's uat environment
+ * Secret text   | docker-registry-ip| The OpenShift docker registry ip
+ *
+ */
+
+def deploy(project, app, tag) {
+    openshift.withProject(project) {
+        def dc = openshift.selector('dc', app);
+        for (trigger in dc.object().spec.triggers) {
+            if (trigger.type == "ImageChange") {
+                def imageStreamName = trigger.imageChangeParams.from.name
+                echo "Current ImageStream tag: ${imageStreamName}"
+                echo "New ImageStream tag: ${app}:${tag}"
+                if (imageStreamName != "${app}:${tag}") {
+                    openshift.selector('dc', app).patch("\'{ \"spec\": { \"triggers\": [{ \"type\": \"ImageChange\", \"imageChangeParams\": { \"automatic\": false, \"containerNames\": [\"${app}\"], \"from\": { \"kind\": \"ImageStreamTag\", \"name\": \"${app}:${tag}\" } } }] } }\'")
+                }
+                def latestVersion = dc.object().status.latestVersion
+                if (latestVersion != 0){
+                    break
+                }
+                echo "Running initial deployment"
+            }
+            openshift.selector('dc', app).rollout().latest()
+
+            timeout(5) {
+                def deploymentObject = openshift.selector('dc', "${app}").object()
+                if (deploymentObject.spec.replicas > 0) {
+                    def latestDeploymentVersion = deploymentObject.status.latestVersion
+                    def replicationController = openshift.selector('rc', "${app}-${latestDeploymentVersion}")
+                    replicationController.untilEach(1) {
+                        def replicationControllerMap = it.object()
+                        echo "Replicas: ${replicationControllerMap.status.readyReplicas}"
+                        return (replicationControllerMap.status.replicas.equals(replicationControllerMap.status.readyReplicas))
+                    }
+                } else {
+                    echo "Deployment has a replica count of 0. Not waiting for Pods to become healthy..."
+                }
+            }
+        }
+    }
+}
+
+def label = "python36-${UUID.randomUUID().toString()}"
+
+def teamDevOpsProject
+def dockerRegistryIp
+
+withCredentials([
+        string(credentialsId: 'devops-project', variable: 'DEVOPS_PROJECT_ID'),
+        string(credentialsId: 'docker-registry-ip', variable: 'DOCKER_REGISTRY_IP')
+]) {
+    teamDevOpsProject = "${env.DEVOPS_PROJECT_ID}"
+    dockerRegistryIp = "${env.DOCKER_REGISTRY_IP}"
+}
+
+echo "Starting to try find pod template: " + dockerRegistryIp + '/' + teamDevOpsProject + '/jenkins-slave-python36-subatomic:2.0'
+
+podTemplate(cloud: "openshift", label: label, serviceAccount:"jenkins", containers: [
+    containerTemplate(name: 'jnlp', image: dockerRegistryIp + '/' + teamDevOpsProject + '/jenkins-slave-python36-subatomic:2.0', ttyEnabled: true, args: '${computer.jnlpmac} ${computer.name}')
+  ])
+{
+  	echo "Trying to get node " + label
+    node(label) {
+      	def projectDevProject
+        def projectSitProject
+        def projectUatProject
+
+        withCredentials([
+                string(credentialsId: 'dev-project', variable: 'DEV_PROJECT_ID'),
+                string(credentialsId: 'sit-project', variable: 'SIT_PROJECT_ID'),
+                string(credentialsId: 'uat-project', variable: 'UAT_PROJECT_ID')
+        ]) {
+            projectDevProject = "${env.DEV_PROJECT_ID}"
+            projectSitProject = "${env.SIT_PROJECT_ID}"
+            projectUatProject = "${env.UAT_PROJECT_ID}"
+        }
+
+        def project = "${env.JOB_NAME.split('/')[0]}"
+        def app = "${env.JOB_NAME.split('/')[1]}"
+        def appBuildConfig = "${project}-${app}"
+
+        def tag
+        stage('Run python stage') {
+            container('jnlp') {
+                stage('Run Python Checks and Tests') {
+                    // Run any tests or build commands here
+                    // sh 'python runTests.py'
+                }
+            }
+        }
+        if (env.BRANCH_NAME == 'master' || !env.BRANCH_NAME) {
+            stage('OpenShift Build') {
+                openshift.withProject(teamDevOpsProject) {
+                    def bc = openshift.selector("bc/${appBuildConfig}")
+
+                    def buildConfig = bc.object()
+                    def outputImage = buildConfig.spec.output.to.name
+                    echo "Current tag: ${outputImage}"
+                    if (outputImage != "${appBuildConfig}:${tag}") {
+                        bc.patch("\'{ \"spec\": { \"output\": { \"to\": { \"name\": \"${appBuildConfig}:${tag}\" } } } }\'")
+                        def build = bc.startBuild();
+                        timeout(5) {
+                            build.untilEach(1) {
+                                return it.object().status.phase == "Complete"
+                            }
+                        }
+                    }
+                }
+            }
+
+            stage('Deploy to DEV') {
+                sh ': Deploying to DEV...'
+
+                openshift.withProject(teamDevOpsProject) {
+                    openshift.tag("${teamDevOpsProject}/${appBuildConfig}:${tag}", "${projectDevProject}/${app}:${tag}")
+                }
+
+                deploy(projectDevProject, app, tag);
+            }
+
+            stage('Deploy to SIT') {
+                sh ': Deploying to SIT...'
+
+                openshift.withProject(projectDevProject) {
+                    openshift.tag("${projectDevProject}/${app}:${tag}", "${projectSitProject}/${app}:${tag}")
+                }
+
+                deploy(projectSitProject, app, tag)
+            }
+
+            stage('Deploy to UAT') {
+                sh ': Deploying to UAT...'
+
+                input "Confirm deployment to UAT"
+
+                openshift.withProject(projectSitProject) {
+                    openshift.tag("${projectSitProject}/${app}:${tag}", "${projectUatProject}/${app}:${tag}")
+                }
+
+                deploy(projectUatProject, app, tag);
+            }
+        }
+    }
+}

--- a/src/gluon/commands/packages/ConfigureBasicPackage.ts
+++ b/src/gluon/commands/packages/ConfigureBasicPackage.ts
@@ -105,7 +105,7 @@ export class ConfigureBasicPackage extends RecursiveParameterRequestCommand
         configurePackage.teamChannel = this.teamChannel;
         configurePackage.openshiftTemplate = definition.openshiftTemplate || "Default";
         configurePackage.jenkinsfileName = definition.jenkinsfile;
-        configurePackage.baseS2IImage = definition.buildConfig.imageStream;
+        configurePackage.imageName = definition.buildConfig.imageStream;
         if (definition.buildConfig.envVariables != null) {
             configurePackage.buildEnvironmentVariables = definition.buildConfig.envVariables;
         }

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -4,7 +4,6 @@ import {
     HandlerResult,
     MappedParameter,
     MappedParameters,
-    Parameter,
     success,
 } from "@atomist/automation-client";
 import {QMConfig} from "../../../config/QMConfig";
@@ -28,7 +27,9 @@ import {
     setJenkinsfileName,
 } from "../../util/recursiveparam/JenkinsParameterSetters";
 import {
+    ImageNameSetter,
     OpenshiftTemplateSetter,
+    setImageNameFromDevOps,
     setOpenshiftTemplate,
 } from "../../util/recursiveparam/OpenshiftParameterSetters";
 import {
@@ -40,7 +41,7 @@ import {GluonToEvent} from "../../util/transform/GluonToEvent";
 
 @CommandHandler("Configure an existing application/library", QMConfig.subatomic.commandPrefix + " configure custom package")
 export class ConfigurePackage extends RecursiveParameterRequestCommand
-    implements GluonTeamNameSetter, GluonProjectNameSetter, GluonApplicationNameSetter, JenkinsfileNameSetter, OpenshiftTemplateSetter {
+    implements GluonTeamNameSetter, GluonProjectNameSetter, GluonApplicationNameSetter, JenkinsfileNameSetter, OpenshiftTemplateSetter, ImageNameSetter {
 
     private static RecursiveKeys = {
         teamName: "TEAM_NAME",
@@ -48,6 +49,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
         applicationName: "APPLICATION_NAME",
         openshiftTemplate: "OPENSHIFT_TEMPLATE",
         jenkinsfileName: "JENKINSFILE_NAME",
+        baseS2IImage: "BASE_S2I_IMAGE",
     };
 
     @MappedParameter(MappedParameters.SlackUserName)
@@ -75,6 +77,12 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
     public teamName: string;
 
     @RecursiveParameter({
+        recursiveKey: ConfigurePackage.RecursiveKeys.baseS2IImage,
+        description: "Please select the base image for the s2i build",
+    })
+    public imageName: string;
+
+    @RecursiveParameter({
         recursiveKey: ConfigurePackage.RecursiveKeys.openshiftTemplate,
         selectionMessage: "Please select the correct openshift template for your package",
     })
@@ -85,11 +93,6 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
         selectionMessage: "Please select the correct jenkinsfile for your package",
     })
     public jenkinsfileName: string;
-
-    @Parameter({
-        description: "Base image for s2i build",
-    })
-    public baseS2IImage: string;
 
     public buildEnvironmentVariables: { [key: string]: string } = {};
 
@@ -113,6 +116,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
         this.addRecursiveSetter(ConfigurePackage.RecursiveKeys.teamName, setGluonTeamName);
         this.addRecursiveSetter(ConfigurePackage.RecursiveKeys.projectName, setGluonProjectName);
         this.addRecursiveSetter(ConfigurePackage.RecursiveKeys.applicationName, setGluonApplicationName);
+        this.addRecursiveSetter(ConfigurePackage.RecursiveKeys.baseS2IImage, setImageNameFromDevOps);
         this.addRecursiveSetter(ConfigurePackage.RecursiveKeys.openshiftTemplate, setOpenshiftTemplate);
         this.addRecursiveSetter(ConfigurePackage.RecursiveKeys.jenkinsfileName, setJenkinsfileName);
     }
@@ -130,7 +134,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
                     {
                         buildEnvironmentVariables: this.buildEnvironmentVariables,
                         openshiftTemplate: this.openshiftTemplate,
-                        baseS2IImage: this.baseS2IImage,
+                        baseS2IImage: this.imageName,
                     },
                     {
                         teamName: this.teamName,

--- a/src/gluon/services/openshift/OCImageService.ts
+++ b/src/gluon/services/openshift/OCImageService.ts
@@ -43,7 +43,7 @@ export class OCImageService {
         }
     }
 
-    public async getSubatomicImageStreamTags(cleanNamespace = true): Promise<OpenshiftResource[]> {
+    public async getSubatomicImageStreamTags(cleanNamespace: boolean = true): Promise<OpenshiftResource[]> {
         logger.debug(`Trying to get subatomic image stream from subatomic namespace`);
         const queryResult = await this.openShiftApi.get.getAllFromNamespace("ImageStreamTag", "subatomic", "v1");
 

--- a/src/gluon/services/openshift/OCService.ts
+++ b/src/gluon/services/openshift/OCService.ts
@@ -174,12 +174,12 @@ export class OCService {
         return createResult.data;
     }
 
-    public async getSubatomicTemplate(templateName: string): Promise<OCCommandResult> {
+    public async getSubatomicTemplate(templateName: string, namespace: string = "subatomic"): Promise<OCCommandResult> {
         logger.debug(`Trying to get subatomic template. templateName: ${templateName}`);
         return await OCCommon.commonCommand("get", "templates",
             [templateName],
             [
-                new SimpleOption("-namespace", "subatomic"),
+                new SimpleOption("-namespace", namespace),
                 new SimpleOption("-output", "json"),
             ],
         );

--- a/src/gluon/tasks/packages/ConfigurePackageInOpenshift.ts
+++ b/src/gluon/tasks/packages/ConfigurePackageInOpenshift.ts
@@ -155,7 +155,7 @@ export class ConfigurePackageInOpenshift extends Task {
             const devOpsProjectId = getProjectDevOpsId(this.packageDetails.teamName);
             logger.info(`Processing app [${appName}] Template for: ${projectId}`);
 
-            const template = await this.ocService.getSubatomicTemplate(this.deploymentDetails.openshiftTemplate);
+            const template = await this.ocService.getSubatomicTemplate(this.deploymentDetails.openshiftTemplate, devOpsProjectId);
             const appBaseTemplate: any = JSON.parse(template.output);
             appBaseTemplate.metadata.namespace = projectId;
             await this.ocService.applyResourceFromDataInNamespace(appBaseTemplate, projectId);

--- a/src/gluon/tasks/team/AddJenkinsToDevOpsEnvironment.ts
+++ b/src/gluon/tasks/team/AddJenkinsToDevOpsEnvironment.ts
@@ -159,6 +159,19 @@ export class AddJenkinsToDevOpsEnvironment extends Task {
 
         await this.createGlobalCredentialsFor("Nexus", jenkinsHost, token, projectId, nexusCredentials);
 
+        const dockerRegistryCredentials = {
+            "": "0",
+            "credentials": {
+                scope: "GLOBAL",
+                id: "docker-registry-ip",
+                secret: `${QMConfig.subatomic.openshiftNonProd.dockerRepoUrl}`,
+                description: "IP For internal docker registry",
+                $class: "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl",
+            },
+        };
+
+        await this.createGlobalCredentialsFor("Docker", jenkinsHost, token, projectId, dockerRegistryCredentials);
+
         const mavenCredentials = {
             "": "0",
             "credentials": {

--- a/src/gluon/util/recursiveparam/JenkinsParameterSetters.ts
+++ b/src/gluon/util/recursiveparam/JenkinsParameterSetters.ts
@@ -2,7 +2,6 @@ import {
     HandlerContext,
     HandlerResult,
     logger,
-    success,
 } from "@atomist/automation-client";
 import {BitBucketServerRepoRef} from "@atomist/automation-client/operations/common/BitBucketServerRepoRef";
 import {GitCommandGitProject} from "@atomist/automation-client/project/git/GitCommandGitProject";
@@ -49,7 +48,7 @@ export async function setJenkinsfileName(
     try {
         await gitProject.findFile("Jenkinsfile");
         commandHandler.jenkinsfileName = JENKINSFILE_EXISTS_FLAG;
-        return success();
+        return await commandHandler.handle(ctx);
     } catch (error) {
         return await createMenuForJenkinsFileSelection(ctx, commandHandler, selectionMessage);
     }


### PR DESCRIPTION
Change notes:
- Added a Python Jenkinsfile
- Added a docker ip credential to jenkins to support the Python jenkins file
- Some generic fixes included around the configure custom package command

Currently there is no default package configuration. I will add that when confident that works for majority of our use cases.

Configuring new kubernetes jenkins slaves is also not configurable through the jenkins api, but can actually be done in the Jenkinsfile itself as seen in the Python Jenkinsfile. 

Closes #426