### PR TITLE
Recursive command message display

### DIFF
--- a/src/gluon/commands/packages/ConfigureBasicPackage.ts
+++ b/src/gluon/commands/packages/ConfigureBasicPackage.ts
@@ -19,6 +19,7 @@ import {
     setGluonTeamName,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {
+    ParameterDisplayType,
     RecursiveParameter,
     RecursiveParameterRequestCommand,
 } from "../../util/recursiveparam/RecursiveParameterRequestCommand";
@@ -113,6 +114,7 @@ export class ConfigureBasicPackage extends RecursiveParameterRequestCommand
         configurePackage.teamName = this.teamName;
         configurePackage.projectName = this.projectName;
         configurePackage.messagePresentationCorrelationId = this.messagePresentationCorrelationId;
+        configurePackage.displayResultMenu = ParameterDisplayType.hide;
 
         return await configurePackage.handle(ctx);
     }

--- a/src/gluon/commands/packages/ConfigureBasicPackage.ts
+++ b/src/gluon/commands/packages/ConfigureBasicPackage.ts
@@ -23,7 +23,7 @@ import {
     RecursiveParameterRequestCommand,
 } from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
-import {createMenu} from "../../util/shared/GenericMenu";
+import {createAndSendMenu} from "../../util/shared/GenericMenu";
 import {ConfigurePackage} from "./ConfigurePackage";
 
 const PACKAGE_DEFINITION_EXTENSION = ".json";
@@ -129,7 +129,7 @@ async function setPackageType(ctx: HandlerContext, commandHandler: ConfigureBasi
 
 async function setPackageDefinitionFile(ctx: HandlerContext, commandHandler: ConfigureBasicPackage, selectionMessage: string): Promise<HandlerResult> {
     const packageDefinitionOptions: string [] = readPackageDefinitions(commandHandler.packageType);
-    return await createMenu(ctx, packageDefinitionOptions.map(packageDefinition => {
+    return await createAndSendMenu(ctx, packageDefinitionOptions.map(packageDefinition => {
             return {
                 value: packageDefinition,
                 text: packageDefinition,

--- a/src/gluon/tasks/packages/ConfigurePackageInJenkins.ts
+++ b/src/gluon/tasks/packages/ConfigurePackageInJenkins.ts
@@ -16,6 +16,7 @@ import {KickOffJenkinsBuild} from "../../commands/jenkins/JenkinsBuild";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
 import {OCService} from "../../services/openshift/OCService";
 import {ApplicationType} from "../../util/packages/Applications";
+import {ParameterDisplayType} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {QMError} from "../../util/shared/Error";
 import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
 import {Task} from "../Task";
@@ -198,6 +199,7 @@ You can kick off the build pipeline for your ${packageTypeString} by clicking th
                         {
                             projectName,
                             applicationName,
+                            displayResultMenu: ParameterDisplayType.hide,
                         }),
                 ],
             }],

--- a/src/gluon/util/bitbucket/Bitbucket.ts
+++ b/src/gluon/util/bitbucket/Bitbucket.ts
@@ -1,11 +1,11 @@
 import {HandleCommand, HandlerContext} from "@atomist/automation-client";
-import {createMenu} from "../shared/GenericMenu";
+import {createMenuAttachment} from "../shared/GenericMenu";
 
-export function menuForBitbucketRepositories(ctx: HandlerContext, bitbucketRepositories: any[],
-                                             command: HandleCommand, message: string = "Please select a Bitbucket repository",
-                                             bitbucketProjectNameVariable: string = "bitbucketRepositoryName",
-                                             thumbUrl = ""): Promise<any> {
-    return createMenu(ctx,
+export function menuAttachmentForBitbucketRepositories(ctx: HandlerContext, bitbucketRepositories: any[],
+                                                       command: HandleCommand, message: string = "Please select a Bitbucket repository",
+                                                       bitbucketProjectNameVariable: string = "bitbucketRepositoryName",
+                                                       thumbUrl = "") {
+    return createMenuAttachment(
         bitbucketRepositories.map(bitbucketRepository => {
             return {
                 value: bitbucketRepository.slug,
@@ -13,6 +13,7 @@ export function menuForBitbucketRepositories(ctx: HandlerContext, bitbucketRepos
             };
         }),
         command,
+        message,
         message,
         "Select Bitbucket Repo",
         bitbucketProjectNameVariable,

--- a/src/gluon/util/packages/Applications.ts
+++ b/src/gluon/util/packages/Applications.ts
@@ -1,6 +1,6 @@
 import {HandleCommand, HandlerContext} from "@atomist/automation-client";
 import * as _ from "lodash";
-import {createMenu} from "../shared/GenericMenu";
+import {createMenuAttachment} from "../shared/GenericMenu";
 
 export enum ApplicationType {
 
@@ -8,10 +8,10 @@ export enum ApplicationType {
     LIBRARY = "LIBRARY",
 }
 
-export function menuForApplications(ctx: HandlerContext, applications: any[],
-                                    command: HandleCommand, message: string = "Please select an application/library",
-                                    applicationNameVariable: string = "applicationName"): Promise<any> {
-    return createMenu(ctx,
+export function menuAttachmentForApplications(ctx: HandlerContext, applications: any[],
+                                              command: HandleCommand, message: string = "Please select an application/library",
+                                              applicationNameVariable: string = "applicationName") {
+    return createMenuAttachment(
         applications.map(application => {
             return {
                 value: application.name,
@@ -19,6 +19,7 @@ export function menuForApplications(ctx: HandlerContext, applications: any[],
             };
         }),
         command,
+        message,
         message,
         "Select Application/Library",
         applicationNameVariable,

--- a/src/gluon/util/project/Project.ts
+++ b/src/gluon/util/project/Project.ts
@@ -1,6 +1,6 @@
 import {HandleCommand, HandlerContext} from "@atomist/automation-client";
 import * as _ from "lodash";
-import {createMenu} from "../shared/GenericMenu";
+import {createMenuAttachment} from "../shared/GenericMenu";
 import {QMTenant} from "../shared/Tenants";
 import {QMTeam} from "../team/Teams";
 
@@ -20,10 +20,10 @@ export function getProjectDisplayName(tenant: string, project: string, environme
     return `${tenant} ${project} ${environment.toUpperCase()}`;
 }
 
-export function menuForProjects(ctx: HandlerContext, projects: any[],
-                                command: HandleCommand, message: string = "Please select a project",
-                                projectNameVariable: string = "projectName"): Promise<any> {
-    return createMenu(ctx,
+export function menuAttachmentForProjects(ctx: HandlerContext, projects: any[],
+                                          command: HandleCommand, message: string = "Please select a project",
+                                          projectNameVariable: string = "projectName") {
+    return createMenuAttachment(
         projects.map(project => {
             return {
                 value: project.name,
@@ -31,6 +31,7 @@ export function menuForProjects(ctx: HandlerContext, projects: any[],
             };
         }),
         command,
+        message,
         message,
         "Select Project",
         projectNameVariable,

--- a/src/gluon/util/recursiveparam/BitbucketParamSetters.ts
+++ b/src/gluon/util/recursiveparam/BitbucketParamSetters.ts
@@ -7,10 +7,10 @@ import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
-import {menuForBitbucketRepositories} from "../bitbucket/Bitbucket";
+import {menuAttachmentForBitbucketRepositories} from "../bitbucket/Bitbucket";
 import {QMError} from "../shared/Error";
 
-export async function setBitbucketRepository(ctx: HandlerContext, commandHandler: BitbucketRepoSetter, selectionMessage: string) {
+export async function setBitbucketRepository(ctx: HandlerContext, commandHandler: BitbucketRepoSetter, selectionMessage: string): Promise<RecursiveSetterResult> {
     const project = await commandHandler.gluonService.projects.gluonProjectFromProjectName(commandHandler.projectName);
     if (_.isEmpty(project.bitbucketProject)) {
         throw new QMError(`The selected project does not have an associated bitbucket project. Please first associate a bitbucket project using the \`${QMConfig.subatomic.commandPrefix} link bitbucket project\` command.`);
@@ -20,14 +20,17 @@ export async function setBitbucketRepository(ctx: HandlerContext, commandHandler
 
     logger.debug(`Bitbucket project [${project.bitbucketProject.name}] has repositories: ${JSON.stringify(bitbucketRepos)}`);
 
-    return await menuForBitbucketRepositories(
-        ctx,
-        bitbucketRepos,
-        commandHandler,
-        selectionMessage,
-        "bitbucketRepositorySlug",
-        "https://raw.githubusercontent.com/absa-subatomic/subatomic-documentation/gh-pages/images/atlassian-bitbucket-logo.png",
-    );
+    return {
+        setterSuccess: false,
+        messagePrompt: menuAttachmentForBitbucketRepositories(
+            ctx,
+            bitbucketRepos,
+            commandHandler,
+            selectionMessage,
+            "bitbucketRepositorySlug",
+            "https://raw.githubusercontent.com/absa-subatomic/subatomic-documentation/gh-pages/images/atlassian-bitbucket-logo.png",
+        ),
+    };
 }
 
 export interface BitbucketRepoSetter {

--- a/src/gluon/util/recursiveparam/GluonParameterSetters.ts
+++ b/src/gluon/util/recursiveparam/GluonParameterSetters.ts
@@ -4,16 +4,16 @@ import {
     logger,
 } from "@atomist/automation-client";
 import {GluonService} from "../../services/gluon/GluonService";
-import {menuForApplications} from "../packages/Applications";
-import {menuForProjects} from "../project/Project";
+import {menuAttachmentForApplications} from "../packages/Applications";
+import {menuAttachmentForProjects} from "../project/Project";
 import {QMError} from "../shared/Error";
-import {menuForTenants} from "../shared/Tenants";
-import {menuForTeams} from "../team/Teams";
+import {menuAttachmentForTenants} from "../shared/Tenants";
+import {menuAttachmentForTeams} from "../team/Teams";
 
 export async function setGluonTeamName(
     ctx: HandlerContext,
     commandHandler: GluonTeamNameSetter,
-    selectionMessage: string = "Please select a team") {
+    selectionMessage: string = "Please select a team"): Promise<RecursiveSetterResult> {
     if (commandHandler.gluonService === undefined) {
         throw new QMError(`setGluonTeamName commandHandler requires gluonService parameter to be defined`);
     }
@@ -26,7 +26,7 @@ export async function setGluonTeamName(
         try {
             const team = await commandHandler.gluonService.teams.gluonTeamForSlackTeamChannel(commandHandler.teamChannel);
             commandHandler.teamName = team.name;
-            return await commandHandler.handle(ctx);
+            return {setterSuccess: true};
         } catch (slackChannelError) {
             logger.info(`Could not find team associated with channel: ${commandHandler.teamChannel}. Trying to find teams member is a part of.`);
         }
@@ -35,11 +35,14 @@ export async function setGluonTeamName(
     }
 
     const teams = await commandHandler.gluonService.teams.gluonTeamsWhoSlackScreenNameBelongsTo(commandHandler.screenName);
-    return await menuForTeams(
-        ctx,
-        teams,
-        commandHandler,
-        selectionMessage);
+    return {
+        setterSuccess: false,
+        messagePrompt: menuAttachmentForTeams(
+            ctx,
+            teams,
+            commandHandler,
+            selectionMessage),
+    };
 }
 
 export interface GluonTeamNameSetter {
@@ -53,7 +56,7 @@ export interface GluonTeamNameSetter {
 export async function setGluonProjectName(
     ctx: HandlerContext,
     commandHandler: GluonProjectNameSetter,
-    selectionMessage: string = "Please select a project") {
+    selectionMessage: string = "Please select a project"): Promise<RecursiveSetterResult> {
 
     if (commandHandler.gluonService === undefined) {
         throw new QMError(`setGluonProjectName commandHandler requires gluonService parameter to be defined`);
@@ -64,12 +67,15 @@ export async function setGluonProjectName(
     }
 
     const projects = await commandHandler.gluonService.projects.gluonProjectsWhichBelongToGluonTeam(commandHandler.teamName);
-    return await menuForProjects(
-        ctx,
-        projects,
-        commandHandler,
-        selectionMessage,
-    );
+    return {
+        setterSuccess: false,
+        messagePrompt: menuAttachmentForProjects(
+            ctx,
+            projects,
+            commandHandler,
+            selectionMessage,
+        ),
+    };
 }
 
 export interface GluonProjectNameSetter {
@@ -82,18 +88,21 @@ export interface GluonProjectNameSetter {
 export async function setGluonTenantName(
     ctx: HandlerContext,
     commandHandler: GluonTenantNameSetter,
-    selectionMessage: string = "Please select a tenant") {
+    selectionMessage: string = "Please select a tenant"): Promise<RecursiveSetterResult> {
 
     if (commandHandler.gluonService === undefined) {
         throw new QMError(`setGluonTenantName commandHandler requires gluonService parameter to be defined`);
     }
 
     const tenants = await commandHandler.gluonService.tenants.gluonTenantList();
-    return await menuForTenants(ctx,
-        tenants,
-        commandHandler,
-        selectionMessage,
-    );
+    return {
+        setterSuccess: false,
+        messagePrompt: menuAttachmentForTenants(
+            tenants,
+            commandHandler,
+            selectionMessage,
+        ),
+    };
 }
 
 export interface GluonTenantNameSetter {
@@ -105,7 +114,7 @@ export interface GluonTenantNameSetter {
 export async function setGluonApplicationName(
     ctx: HandlerContext,
     commandHandler: GluonApplicationNameSetter,
-    selectionMessage: string = "Please select an application") {
+    selectionMessage: string = "Please select an application"): Promise<RecursiveSetterResult> {
     if (commandHandler.gluonService === undefined) {
         throw new QMError(`setGluonApplicationName commandHandler requires gluonService parameter to be defined`);
     }
@@ -115,11 +124,14 @@ export async function setGluonApplicationName(
     }
 
     const applications = await commandHandler.gluonService.applications.gluonApplicationsLinkedToGluonProject(commandHandler.projectName);
-    return await menuForApplications(
-        ctx,
-        applications,
-        commandHandler,
-        selectionMessage);
+    return {
+        setterSuccess: false,
+        messagePrompt: menuAttachmentForApplications(
+            ctx,
+            applications,
+            commandHandler,
+            selectionMessage),
+    };
 }
 
 export interface GluonApplicationNameSetter {

--- a/src/gluon/util/recursiveparam/OpenshiftParameterSetters.ts
+++ b/src/gluon/util/recursiveparam/OpenshiftParameterSetters.ts
@@ -14,7 +14,7 @@ export async function setOpenshiftTemplate(
     ctx: HandlerContext,
     commandHandler: OpenshiftTemplateSetter,
     selectionMessage: string = "Please select an Openshift template",
-) {
+): Promise<RecursiveSetterResult> {
 
     if (commandHandler.ocService === undefined) {
         throw new QMError(`setOpenshiftTemplate commandHandler requires the ocService parameter to be defined`);
@@ -76,7 +76,7 @@ export async function setImageName(
 export async function setImageNameFromDevOps(
     ctx: HandlerContext,
     commandHandler: ImageNameSetter,
-    selectionMessage: string = "Please select an image") {
+    selectionMessage: string = "Please select an image"): Promise<RecursiveSetterResult> {
     if (commandHandler.ocService === undefined) {
         throw new QMError(`setImageName commandHandler requires ocService parameter to be defined`);
     }

--- a/src/gluon/util/recursiveparam/OpenshiftParameterSetters.ts
+++ b/src/gluon/util/recursiveparam/OpenshiftParameterSetters.ts
@@ -7,7 +7,7 @@ import {QMConfig} from "../../../config/QMConfig";
 import {OpenshiftResource} from "../../../openshift/api/resources/OpenshiftResource";
 import {OCService} from "../../services/openshift/OCService";
 import {QMError} from "../shared/Error";
-import {createMenu} from "../shared/GenericMenu";
+import {createMenuAttachment} from "../shared/GenericMenu";
 import {getDevOpsEnvironmentDetails} from "../team/Teams";
 
 export async function setOpenshiftTemplate(
@@ -30,16 +30,20 @@ export async function setOpenshiftTemplate(
 
     const namespace = getDevOpsEnvironmentDetails(commandHandler.teamName).openshiftProjectId;
     const templates = await commandHandler.ocService.getSubatomicAppTemplates(namespace);
-    return await createMenu(ctx, templates.map(template => {
-            return {
-                value: template.metadata.name,
-                text: template.metadata.name,
-            };
-        }),
-        commandHandler,
-        selectionMessage,
-        "Select a template",
-        "openshiftTemplate");
+    return {
+        setterSuccess: false,
+        messagePrompt: createMenuAttachment(templates.map(template => {
+                return {
+                    value: template.metadata.name,
+                    text: template.metadata.name,
+                };
+            }),
+            commandHandler,
+            selectionMessage,
+            selectionMessage,
+            "Select a template",
+            "openshiftTemplate"),
+    };
 }
 
 export interface OpenshiftTemplateSetter {
@@ -63,7 +67,10 @@ export async function setImageName(
 
     const images = await commandHandler.ocService.getSubatomicImageStreamTags();
 
-    return await presentImageMenu(ctx, commandHandler, selectionMessage, images);
+    return {
+        setterSuccess: false,
+        messagePrompt: presentImageMenu(ctx, commandHandler, selectionMessage, images),
+    };
 }
 
 export async function setImageNameFromDevOps(
@@ -86,16 +93,18 @@ export async function setImageNameFromDevOps(
 
     const images = await commandHandler.ocService.getSubatomicImageStreamTags(devOpsEnvironment.openshiftProjectId);
 
-    return await presentImageMenu(ctx, commandHandler, selectionMessage, images);
+    return {
+        setterSuccess: false,
+        messagePrompt: presentImageMenu(ctx, commandHandler, selectionMessage, images),
+    };
 }
 
-async function presentImageMenu(ctx: HandlerContext,
-                                commandHandler: ImageNameSetter,
-                                selectionMessage: string,
-                                images: OpenshiftResource[]) {
+function presentImageMenu(ctx: HandlerContext,
+                          commandHandler: ImageNameSetter,
+                          selectionMessage: string,
+                          images: OpenshiftResource[]) {
     logger.info(JSON.stringify(images, null, 2));
-    return await createMenu(
-        ctx,
+    return createMenuAttachment(
         images.map(image => {
             return {
                 value: image.metadata.name,
@@ -103,6 +112,7 @@ async function presentImageMenu(ctx: HandlerContext,
             };
         }),
         commandHandler,
+        selectionMessage,
         selectionMessage,
         "Select Image",
         "imageName");

--- a/src/gluon/util/recursiveparam/ParameterStatusDisplay.ts
+++ b/src/gluon/util/recursiveparam/ParameterStatusDisplay.ts
@@ -1,4 +1,5 @@
 import {SlackMessage} from "@atomist/slack-messages";
+import {ParameterDisplayType} from "./RecursiveParameterRequestCommand";
 
 export class ParameterStatusDisplay {
 
@@ -15,16 +16,25 @@ export class ParameterStatusDisplay {
         this.paramOrder.push(paramName);
     }
 
-    public getDisplayMessage(commandName: string): SlackMessage {
-        let textDisplay = `Preparing command *${commandName}*: \n`;
+    public getDisplayMessage(commandName: string, displayRequested: ParameterDisplayType): SlackMessage {
+        const attachments = [];
+        if (displayRequested === ParameterDisplayType.show) {
+            let textDisplay = `Preparing command *${commandName}*: \n`;
 
-        for (const parameter of this.paramOrder) {
-            textDisplay += `*${parameter}*: ${this.setParameters[parameter]}\n`;
+            for (const parameter of this.paramOrder) {
+                textDisplay += `*${parameter}*\n${this.setParameters[parameter]}\n\n`;
+            }
+            attachments.push(
+                {
+                    text: textDisplay,
+                    color: "#45B254",
+                    fallback: "",
+                },
+            );
         }
 
         return {
-            text: textDisplay,
-            attachments: [],
+            attachments,
         };
     }
 }

--- a/src/gluon/util/recursiveparam/ParameterStatusDisplay.ts
+++ b/src/gluon/util/recursiveparam/ParameterStatusDisplay.ts
@@ -1,0 +1,30 @@
+import {SlackMessage} from "@atomist/slack-messages";
+
+export class ParameterStatusDisplay {
+
+    private readonly setParameters: { [key: string]: string };
+    private readonly paramOrder: string[];
+
+    constructor() {
+        this.setParameters = {};
+        this.paramOrder = [];
+    }
+
+    public setParam(paramName: string, paramValue: string) {
+        this.setParameters[paramName] = paramValue;
+        this.paramOrder.push(paramName);
+    }
+
+    public getDisplayMessage(commandName: string): SlackMessage {
+        let textDisplay = `Preparing command *${commandName}*: \n`;
+
+        for (const parameter of this.paramOrder) {
+            textDisplay += `*${parameter}*: ${this.setParameters[parameter]}\n`;
+        }
+
+        return {
+            text: textDisplay,
+            attachments: [],
+        };
+    }
+}

--- a/src/gluon/util/recursiveparam/RecursiveParameterRequestCommand.ts
+++ b/src/gluon/util/recursiveparam/RecursiveParameterRequestCommand.ts
@@ -12,6 +12,7 @@ import {
 import _ = require("lodash");
 import uuid = require("uuid");
 import {handleQMError, QMError, ResponderMessageClient} from "../shared/Error";
+import {ParameterStatusDisplay} from "./ParameterStatusDisplay";
 
 export abstract class RecursiveParameterRequestCommand implements HandleCommand<HandlerResult> {
 
@@ -27,12 +28,16 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
 
     private recursiveParameterMap: { [key: string]: RecursiveParameterMapping };
 
+    private parameterStatusDisplay: ParameterStatusDisplay;
+
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         if (_.isEmpty(this.messagePresentationCorrelationId)) {
             this.messagePresentationCorrelationId = uuid.v4();
         }
 
+        this.recursiveParameterOrder = [];
         this.configureParameterSetters();
+        this.updateParameterStatusDisplayMessage();
         if (!this.recursiveParametersAreSet()) {
             try {
                 return await this.requestNextUnsetParameter(ctx);
@@ -40,6 +45,8 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
                 return await this.handleRequestNextParameterError(ctx, error);
             }
         }
+
+        await ctx.messageClient.respond(this.parameterStatusDisplay.getDisplayMessage(this.getIntent()), {id: this.messagePresentationCorrelationId});
 
         return await this.runCommand(ctx);
     }
@@ -85,17 +92,16 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
         const dynamicClassInstance: any = this;
         for (const recursiveKey of this.recursiveParameterOrder) {
             const propertyKey = this.recursiveParameterMap[recursiveKey].propertyName;
-            if (_.isEmpty(dynamicClassInstance[propertyKey])) {
+            const propertyValue = dynamicClassInstance[propertyKey];
+            if (_.isEmpty(propertyValue)) {
                 logger.info(`Setting parameter ${propertyKey}.`);
                 const result = await this.recursiveParameterMap[recursiveKey].parameterSetter(ctx, this, this.recursiveParameterMap[recursiveKey].selectionMessage);
                 if (result.setterSuccess) {
                     return await this.handle(ctx);
                 } else {
-                    return ctx.messageClient.respond({
-                        attachments: [
-                            result.messagePrompt,
-                        ],
-                    }, {id: this.messagePresentationCorrelationId});
+                    const displayMessage = this.parameterStatusDisplay.getDisplayMessage(this.getIntent());
+                    displayMessage.attachments.push(result.messagePrompt);
+                    return await ctx.messageClient.respond(displayMessage, {id: this.messagePresentationCorrelationId});
                 }
             }
         }
@@ -107,6 +113,7 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
         for (const recursiveKey of this.recursiveParameterList) {
 
             const propertyKey = this.recursiveParameterMap[recursiveKey].propertyName;
+            const propertyValue = dynamicClassInstance[propertyKey];
 
             if (this.recursiveParameterMap[recursiveKey].parameterSetter === undefined) {
                 logger.error(`Setter for recursive parameter ${propertyKey} is not set.`);
@@ -116,13 +123,38 @@ export abstract class RecursiveParameterRequestCommand implements HandleCommand<
             logger.debug(`Recursive Param with recursive key ${recursiveKey} details:\nProperty: ${propertyKey}\nForceSet: ${this.recursiveParameterMap[recursiveKey].forceSet}\nValue: ${dynamicClassInstance[propertyKey]}`);
 
             if (this.recursiveParameterMap[recursiveKey].forceSet &&
-                _.isEmpty(dynamicClassInstance[propertyKey])) {
+                _.isEmpty(propertyValue)) {
                 logger.info(`Recursive parameter ${propertyKey} not set.`);
                 parametersAreSet = false;
                 break;
             }
         }
         return parametersAreSet;
+    }
+
+    private updateParameterStatusDisplayMessage() {
+        this.parameterStatusDisplay = new ParameterStatusDisplay();
+        const dynamicClassInstance: any = this;
+        for (const recursiveKey of this.recursiveParameterOrder) {
+
+            const propertyKey = this.recursiveParameterMap[recursiveKey].propertyName;
+            const propertyValue = dynamicClassInstance[propertyKey];
+
+            if (!(this.recursiveParameterMap[recursiveKey].forceSet &&
+                _.isEmpty(propertyValue))) {
+                this.parameterStatusDisplay.setParam(propertyKey, propertyValue);
+            }
+        }
+    }
+
+    private getIntent(): string {
+        const dynamicClassInstance: any = this;
+        const intentValue = dynamicClassInstance.__intent;
+        if (!_.isEmpty(intentValue)) {
+            return intentValue;
+        }
+
+        return "Unknown Command";
     }
 
     private async handleRequestNextParameterError(ctx: HandlerContext, error) {

--- a/src/gluon/util/recursiveparam/RecursiveSetterResult.ts
+++ b/src/gluon/util/recursiveparam/RecursiveSetterResult.ts
@@ -1,0 +1,4 @@
+interface RecursiveSetterResult {
+    setterSuccess: boolean;
+    messagePrompt?: any;
+}

--- a/src/gluon/util/shared/GenericMenu.ts
+++ b/src/gluon/util/shared/GenericMenu.ts
@@ -1,14 +1,29 @@
 import {
-    HandleCommand, HandlerContext,
+    HandleCommand,
+    HandlerContext,
     logger,
 } from "@atomist/automation-client";
 import {menuForCommand} from "@atomist/automation-client/spi/message/MessageClient";
 
-export function createMenu(ctx: HandlerContext, menuOptions: Array<{ value: string, text: string }>,
-                           command: HandleCommand, description: string, selectionMessage: string,
-                           resultVariableName: string, thumbUrl: string = ""): Promise<any> {
+export function createAndSendMenu(ctx: HandlerContext, menuOptions: Array<{ value: string, text: string }>,
+                                  command: HandleCommand, description: string, selectionMessage: string,
+                                  resultVariableName: string, thumbUrl: string = ""): Promise<any> {
+    const attachment: { [k: string]: any } = createMenuAttachment(menuOptions, command, "", description, selectionMessage, resultVariableName, thumbUrl);
+    logger.info(JSON.stringify(menuOptions));
+    return ctx.messageClient.respond({
+        text: description,
+        attachments: [
+            attachment,
+        ],
+    });
+}
+
+export function createMenuAttachment(menuOptions: Array<{ value: string, text: string }>,
+                                     command: HandleCommand, text: string, fallback: string, selectionMessage: string,
+                                     resultVariableName: string, thumbUrl: string = "") {
     const attachment: { [k: string]: any } = {
-        fallback: description,
+        text,
+        fallback,
         actions: [
             menuForCommand({
                     text: selectionMessage, options:
@@ -20,11 +35,5 @@ export function createMenu(ctx: HandlerContext, menuOptions: Array<{ value: stri
     if (thumbUrl.length > 0) {
         attachment.thumb_url = thumbUrl;
     }
-    logger.info(JSON.stringify(menuOptions));
-    return ctx.messageClient.respond({
-        text: description,
-        attachments: [
-            attachment,
-        ],
-    });
+    return attachment;
 }

--- a/src/gluon/util/shared/Tenants.ts
+++ b/src/gluon/util/shared/Tenants.ts
@@ -1,10 +1,10 @@
-import {HandleCommand, HandlerContext} from "@atomist/automation-client";
-import {createMenu} from "./GenericMenu";
+import {HandleCommand} from "@atomist/automation-client";
+import {createMenuAttachment} from "./GenericMenu";
 
-export function menuForTenants(ctx: HandlerContext, tenants: any[],
-                               command: HandleCommand, message: string = "Please select a tenant",
-                               tenantNameVariable: string = "tenantName"): Promise<any> {
-    return createMenu(ctx,
+export function menuAttachmentForTenants(tenants: any[],
+                                         command: HandleCommand, message: string = "Please select a tenant",
+                                         tenantNameVariable: string = "tenantName") {
+    return createMenuAttachment(
         tenants.map(tenant => {
             return {
                 value: tenant.name,
@@ -12,6 +12,7 @@ export function menuForTenants(ctx: HandlerContext, tenants: any[],
             };
         }),
         command,
+        message,
         message,
         "Select Tenant",
         tenantNameVariable,

--- a/src/gluon/util/team/Teams.ts
+++ b/src/gluon/util/team/Teams.ts
@@ -6,12 +6,12 @@ import {
 import * as _ from "lodash";
 import * as graphql from "../../../typings/types";
 import {QMMember} from "../member/Members";
-import {createMenu} from "../shared/GenericMenu";
+import {createMenuAttachment} from "../shared/GenericMenu";
 
-export function menuForTeams(ctx: HandlerContext, teams: any[],
-                             command: HandleCommand, message: string = "Please select a team",
-                             projectNameVariable: string = "teamName"): Promise<any> {
-    return createMenu(ctx,
+export function menuAttachmentForTeams(ctx: HandlerContext, teams: any[],
+                                       command: HandleCommand, message: string = "Please select a team",
+                                       projectNameVariable: string = "teamName") {
+    return createMenuAttachment(
         teams.map(team => {
             return {
                 value: team.name,
@@ -19,6 +19,7 @@ export function menuForTeams(ctx: HandlerContext, teams: any[],
             };
         }),
         command,
+        message,
         message,
         "Select Team",
         projectNameVariable,


### PR DESCRIPTION
Improved how recursive commands request parameters through menus. The new look is as follows:

<img width="518" alt="screen shot 2018-10-10 at 15 05 25" src="https://user-images.githubusercontent.com/4415392/46738281-15f3d300-cc9e-11e8-9826-8104744ad10b.png">

Options are available to hide this display if we wish. This is useful in cases such as where we have a command that calls another command and you do not want menus for both / a button has an underlying command with all parameters already set and you dont want a huge menu displaying after clicking the button.

Closes #425  