### PR TITLE
User joins channel fix

### DIFF
--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -137,7 +137,7 @@ export class BotJoinedChannel implements HandleEvent<any> {
                 text: `Welcome to *${botJoinedChannel.channel.name}* team channel @${userName}!`,
                 attachments: [{
                     fallback: `Welcome to *${botJoinedChannel.channel.name}* team channel!`,
-                    text: "Unfortunately you do not seem to have been onboarded to Subatomic. To onboard yourself press the button below.",
+                    text: "You don't have a Subatomic account",
                     actions: [
                         buttonForCommand(
                             {

--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -15,6 +15,7 @@ import {
     buttonForCommand,
 } from "@atomist/automation-client/spi/message/MessageClient";
 import {SlackMessage, url} from "@atomist/slack-messages";
+import _ = require("lodash");
 import {QMConfig} from "../../../config/QMConfig";
 import {OnboardMember} from "../../commands/member/OnboardMember";
 import {AddMemberToTeam} from "../../commands/team/AddMemberToTeam";

--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -88,62 +88,65 @@ export class BotJoinedChannel implements HandleEvent<any> {
 
                 return await this.sendBotTeamWelcomeMessage(ctx, channelNameString, botJoinedChannel.channel.channelId);
             } else {
-                const userName = botJoinedChannel.user.screenName;
-
-                logger.info("Checking whether the user onboarded");
-                const destination =  await addressSlackChannelsFromContext(ctx, botJoinedChannel.channel.channelId);
-                let existingUser;
-                try {
-                    existingUser = await this.gluonService.members.gluonMemberFromScreenName(userName);
-
-                    logger.info("Checking whether the user is a part of the team");
-                    for (const team of existingUser.teams) {
-                        if (team.slack.teamChannel === botJoinedChannel.channel.name) {
-                            logger.info("User is a part of this team.");
-                            return await success();
-                        }
-                    }
-                    const slackMessage: SlackMessage = {
-                        text: `Welcome to *${botJoinedChannel.channel.name}* team channel @${userName}!`,
-                        attachments: [{
-                            fallback: `Welcome to *${botJoinedChannel.channel.name}* team channel!`,
-                            text: "Unfortunately you are not registered as a member/owner of this team. If you would like to join this team please get a team owner (sub list team members`) to add you.",
-                            actions: [
-                                buttonForCommand(
-                                    {
-                                        text: `Add ${userName}`,
-                                        style: "primary",
-                                    },
-                                    new AddMemberToTeam(),
-                                    {
-                                        slackName: botJoinedChannel.user.userId
-                                        ,
-                                    }),
-                            ],
-                        }],
-                    };
-                    return ctx.messageClient.send(slackMessage, destination);
-                } catch (error) {
-                    const msg: SlackMessage = {
-                        text: `Welcome to *${botJoinedChannel.channel.name}* team channel @${userName}!`,
-                        attachments: [{
-                            fallback: `Welcome to *${botJoinedChannel.channel.name}* team channel!`,
-                            text: "Unfortunately you do not seem to have been onboarded to Subatomic. To onboard yourself press the button below.",
-                            actions: [
-                                buttonForCommand(
-                                    {
-                                        text: "Onboard me",
-                                    },
-                                    new OnboardMember()),
-                            ],
-                        }],
-                    };
-                    return ctx.messageClient.send(msg, destination);
-                }
+                return this.processUserJoinedChannelEvent(ctx, botJoinedChannel);
             }
-            return await success();
         } catch (error) {
             return await handleQMError(new ChannelMessageClient(ctx).addDestination(botJoinedChannel.channel.channelId), error);
+        }
+    }
+
+    private async processUserJoinedChannelEvent(ctx: HandlerContext, botJoinedChannel: any) {
+        const userName = botJoinedChannel.user.screenName;
+
+        logger.info("Checking whether the user onboarded");
+        const destination = await addressSlackChannelsFromContext(ctx, botJoinedChannel.channel.channelId);
+        let existingUser;
+        try {
+            existingUser = await this.gluonService.members.gluonMemberFromScreenName(userName);
+
+            logger.info("Checking whether the user is a part of the team");
+            for (const team of existingUser.teams) {
+                if (!_.isEmpty(team.slack) && team.slack.teamChannel === botJoinedChannel.channel.name) {
+                    logger.info("User is a part of this team.");
+                    return await success();
+                }
+            }
+            const slackMessage: SlackMessage = {
+                text: `Welcome to *${botJoinedChannel.channel.name}* team channel @${userName}!`,
+                attachments: [{
+                    fallback: `Welcome to *${botJoinedChannel.channel.name}* team channel!`,
+                    text: "Unfortunately you are not registered as a member/owner of this team. If you would like to join this team please get a team owner (sub list team members`) to add you.",
+                    actions: [
+                        buttonForCommand(
+                            {
+                                text: `Add ${userName}`,
+                                style: "primary",
+                            },
+                            new AddMemberToTeam(),
+                            {
+                                slackName: botJoinedChannel.user.userId
+                                ,
+                            }),
+                    ],
+                }],
+            };
+            return ctx.messageClient.send(slackMessage, destination);
+        } catch (error) {
+            const msg: SlackMessage = {
+                text: `Welcome to *${botJoinedChannel.channel.name}* team channel @${userName}!`,
+                attachments: [{
+                    fallback: `Welcome to *${botJoinedChannel.channel.name}* team channel!`,
+                    text: "Unfortunately you do not seem to have been onboarded to Subatomic. To onboard yourself press the button below.",
+                    actions: [
+                        buttonForCommand(
+                            {
+                                text: "Onboard me",
+                            },
+                            new OnboardMember()),
+                    ],
+                }],
+            };
+            return ctx.messageClient.send(msg, destination);
         }
     }
 
@@ -171,7 +174,7 @@ If you haven't already, you might want to:
                 ],
             }],
         };
-        const destination =  await addressSlackChannelsFromContext(ctx, channelId);
+        const destination = await addressSlackChannelsFromContext(ctx, channelId);
         return await ctx.messageClient.send(msg, destination);
     }
 

--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -116,7 +116,7 @@ export class BotJoinedChannel implements HandleEvent<any> {
                 text: `Welcome to *${botJoinedChannel.channel.name}* team channel @${userName}!`,
                 attachments: [{
                     fallback: `Welcome to *${botJoinedChannel.channel.name}* team channel!`,
-                    text: "Unfortunately you are not registered as a member/owner of this team. If you would like to join this team please get a team owner (sub list team members`) to add you.",
+                    text: "You are not part of this team. To join this team get a team owner (`sub list team members`) to add you.",
                     actions: [
                         buttonForCommand(
                             {


### PR DESCRIPTION
Fixes a case where a user is associated with a team that is not linked to a slack channel resulting in the wrong message being presented.

Closes #460 