### PR TITLE
Immutability Preservation in OpenShift API

### DIFF
--- a/src/openshift/api/common/ImmutabilityPreserver.ts
+++ b/src/openshift/api/common/ImmutabilityPreserver.ts
@@ -1,0 +1,71 @@
+import _ = require("lodash");
+import {OpenshiftResource} from "../resources/OpenshiftResource";
+
+export class ImmutabilityPreserver {
+
+    private static immutableProperties: { [key: string]: string[] };
+
+    constructor() {
+        if (_.isEmpty(ImmutabilityPreserver.immutableProperties)) {
+            ImmutabilityPreserver.immutableProperties = {
+                service: [
+                    "spec.clusterIP",
+                ],
+            };
+        }
+    }
+
+    public preserveImmutability(newResource: OpenshiftResource, oldResource: OpenshiftResource) {
+        if (oldResource.metadata.uid !== undefined) {
+            newResource.metadata.uid = oldResource.metadata.uid;
+        }
+        if (oldResource.metadata.resourceVersion !== undefined) {
+            newResource.metadata.resourceVersion = oldResource.metadata.resourceVersion;
+        }
+
+        if (ImmutabilityPreserver.immutableProperties.hasOwnProperty(newResource.kind.toLowerCase())) {
+            for (const immutableProperty of ImmutabilityPreserver.immutableProperties[newResource.kind.toLowerCase()]) {
+                const propertyValue = this.getPropertyValue(oldResource, immutableProperty.split("."));
+                if (propertyValue !== undefined) {
+                    this.setPropertyValue(newResource, immutableProperty.split("."), propertyValue);
+                }
+            }
+        }
+    }
+
+    private getPropertyValue(baseObject: any, propertyReference: string[]) {
+        if (propertyReference.length === 0) {
+            return baseObject;
+        }
+        if (baseObject.hasOwnProperty(propertyReference[0])) {
+            return this.getPropertyValue(baseObject[propertyReference[0]], propertyReference.slice(1));
+        } else {
+            return undefined;
+        }
+    }
+
+    private setPropertyValue(baseObject: any, propertyReference: string[], value: any) {
+        if (propertyReference.length === 1) {
+            baseObject[propertyReference[0]] = value;
+            return;
+        }
+        if (baseObject.hasOwnProperty(propertyReference[0])) {
+            return this.setPropertyValue(baseObject[propertyReference[0]], propertyReference.slice(1), value);
+        } else {
+            baseObject[propertyReference[0]] = this.createProperty(propertyReference.slice(1), value);
+            return;
+        }
+    }
+
+    private createProperty(propertyReferenceOriginal: string[], value: any) {
+        const propertyReference = _.clone(propertyReferenceOriginal);
+        const propertyName = propertyReference.pop();
+        const newValue: { [key: string]: any } = {};
+        newValue[propertyName] = value;
+        if (propertyReference.length === 0) {
+            return newValue;
+        } else {
+            return this.createProperty(propertyReference, value);
+        }
+    }
+}

--- a/test/openshift/api/common/ImmutabilityPreserverTest.ts
+++ b/test/openshift/api/common/ImmutabilityPreserverTest.ts
@@ -1,0 +1,122 @@
+import _ = require("lodash");
+import * as assert from "power-assert";
+import {ImmutabilityPreserver} from "../../../../src/openshift/api/common/ImmutabilityPreserver";
+import {OpenshiftResource} from "../../../../src/openshift/api/resources/OpenshiftResource";
+
+describe("Openshift Api Common ImmutabilityPreserver test", () => {
+
+    it("should preserve clusterIP in new resource with spec property without modifying existing properties", () => {
+
+        const immutabilityPreserver = new ImmutabilityPreserver();
+
+        const newResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {},
+            spec: {
+                someRandomProperty: "1",
+            },
+        };
+
+        const oldResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {},
+            spec: {
+                clusterIP: "1.1.1.1",
+            },
+        };
+
+        immutabilityPreserver.preserveImmutability(newResource, oldResource);
+
+        assert.equal(newResource.spec.clusterIP, "1.1.1.1");
+        assert.equal(newResource.spec.someRandomProperty, "1");
+    });
+
+    it("should preserve clusterIP in new resource without spec property without modifying existing properties", () => {
+        const immutabilityPreserver = new ImmutabilityPreserver();
+
+        const newResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {},
+            something: {
+                someRandomProperty: "1",
+            },
+        };
+
+        const oldResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {},
+            spec: {
+                clusterIP: "1.1.1.1",
+            },
+        };
+
+        immutabilityPreserver.preserveImmutability(newResource, oldResource);
+
+        assert.equal(newResource.spec.clusterIP, "1.1.1.1");
+        assert.equal(newResource.something.someRandomProperty, "1");
+    });
+
+    it("should preserve uid and resourceVersion in new resource without spec property without modifying existing properties", () => {
+        const immutabilityPreserver = new ImmutabilityPreserver();
+
+        const newResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {
+                label: "1",
+            },
+            something: {
+                someRandomProperty: "1",
+            },
+        };
+
+        const oldResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {
+                uid: "1",
+                resourceVersion: "799",
+            },
+        };
+
+        immutabilityPreserver.preserveImmutability(newResource, oldResource);
+
+        assert.equal(newResource.metadata.uid, "1");
+        assert.equal(newResource.metadata.resourceVersion, "799");
+        assert.equal(newResource.something.someRandomProperty, "1");
+        assert.equal(newResource.metadata.label, "1");
+    });
+
+    it("should not modify the new resource if there are no immutable properties", () => {
+        const immutabilityPreserver = new ImmutabilityPreserver();
+
+        const newResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {
+                label: "1",
+            },
+            something: {
+                someRandomProperty: "1",
+            },
+        };
+
+        const newResourceClone = _.cloneDeep(newResource);
+
+        const oldResource: OpenshiftResource = {
+            apiVersion: "v1",
+            kind: "Service",
+            metadata: {
+                label: "2",
+            },
+        };
+
+        immutabilityPreserver.preserveImmutability(newResource, oldResource);
+
+        assert.deepEqual(newResource, newResourceClone);
+    });
+});


### PR DESCRIPTION
Added functionality to make sure that immutable properties are not modified.

Need to add a list of immutable properties still but we can do this as we go along.

Closes #465 