### PR TITLE
Added command to allow jenkins bitbucket access credential recreation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -326,7 +326,7 @@
             "@types/json-stringify-safe": "5.0.0",
             "@types/lodash": "4.14.116",
             "@types/minimatch": "3.0.3",
-            "@types/node": "10.9.4",
+            "@types/node": "10.11.7",
             "@types/passport": "0.4.6",
             "@types/passport-http": "0.3.6",
             "@types/passport-http-bearer": "1.0.33",
@@ -425,7 +425,7 @@
           "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
           "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
           "requires": {
-            "@types/node": "10.9.4"
+            "@types/node": "10.11.7"
           }
         },
         "@types/lodash": {
@@ -590,7 +590,7 @@
             "@types/json-stringify-safe": "5.0.0",
             "@types/lodash": "4.14.104",
             "@types/minimatch": "3.0.3",
-            "@types/node": "10.9.4",
+            "@types/node": "10.11.7",
             "@types/passport": "0.4.6",
             "@types/passport-http": "0.3.6",
             "@types/passport-http-bearer": "1.0.33",
@@ -764,7 +764,7 @@
       "requires": {
         "@atomist/slack-messages": "1.0.0",
         "@types/lodash": "4.14.116",
-        "@types/node": "10.9.4",
+        "@types/node": "10.11.7",
         "axios": "0.18.0",
         "base64-js": "1.3.0",
         "copyfiles": "2.1.0",
@@ -901,7 +901,7 @@
         "@types/jssha": "0.0.29",
         "@types/lodash": "4.14.116",
         "@types/marked": "0.4.1",
-        "@types/node": "10.9.4",
+        "@types/node": "10.11.7",
         "@types/node-notifier": "0.0.28",
         "@types/open": "0.0.29",
         "@types/sprintf-js": "1.1.0",
@@ -956,7 +956,7 @@
           "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
           "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
           "requires": {
-            "@types/node": "10.9.4"
+            "@types/node": "10.11.7"
           }
         },
         "@types/lodash": {
@@ -1267,7 +1267,7 @@
       "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
       "requires": {
         "@types/connect": "3.4.32",
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/commander": {
@@ -1284,7 +1284,7 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/continuation-local-storage": {
@@ -1292,7 +1292,7 @@
       "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha1-oz4N+dzptCTRyY/E/evYV43O7H4=",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/cors": {
@@ -1308,7 +1308,7 @@
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.0.tgz",
       "integrity": "sha512-evp2ZGsFw9YKprDbg8ySgC9NA15g3YgiI8ANkGmKKvvi0P2aDGYLPxQIC5qfeKNUOe3TjABVGuah6omPRpIYhg==",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/empower": {
@@ -1342,7 +1342,7 @@
       "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/fs-extra": {
@@ -1350,7 +1350,7 @@
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/glob": {
@@ -1360,7 +1360,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "2.0.29",
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/graphql": {
@@ -1441,15 +1441,14 @@
     "@types/node": {
       "version": "10.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
-      "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
-      "dev": true
+      "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg=="
     },
     "@types/node-notifier": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-0.0.28.tgz",
       "integrity": "sha1-hro9OqjZGDUswxkdiN4yiyDck8E=",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/normalize-package-data": {
@@ -1666,7 +1665,7 @@
       "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
       "requires": {
         "@types/glob": "5.0.35",
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/sprintf-js": {
@@ -1679,7 +1678,7 @@
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
       "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/tmp": {
@@ -1697,7 +1696,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
     },
     "@types/winston": {
@@ -1714,8 +1713,14 @@
       "integrity": "sha512-i/dVaSjmTM92EFFFhmGL6AmHzvJ70XpAXmMLvNKh3JrRTGOiXvejfxe5+OSxcJK0paGOYHDaRLS8nXW6/FxSxg==",
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "10.9.4"
+        "@types/node": "10.11.7"
       }
+    },
+    "@types/xmlbuilder": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.34.tgz",
+      "integrity": "sha512-yVsHfYqJblSEg3DvUhGndpCZBZz2GiGVmqMa04fbGro2xzxRj85Q7MQ4os+MaXmKcpCDD42MXuxUWfoUKTuVdQ==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "11.1.1",
@@ -2095,7 +2100,7 @@
     },
     "apollo-tracing": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.1.4.tgz",
       "integrity": "sha512-Uv+1nh5AsNmC3m130i2u3IqbS+nrxyVV3KYimH5QKsdPjxxIQB3JAT+jJmpeDxBel8gDVstNmCh82QSLxLSIdQ==",
       "dev": true,
       "requires": {
@@ -5513,7 +5518,7 @@
     },
     "graphql-extensions": {
       "version": "0.0.10",
-      "resolved": "http://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.0.10.tgz",
       "integrity": "sha512-TnQueqUDCYzOSrpQb3q1ngDSP2otJSF+9yNLrQGPzkMsvnQ+v6e2d5tl+B35D4y+XpmvVnAn4T3ZK28mkILveA==",
       "dev": true,
       "requires": {
@@ -5523,7 +5528,7 @@
     },
     "graphql-subscriptions": {
       "version": "0.5.8",
-      "resolved": "http://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-0.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-0.5.8.tgz",
       "integrity": "sha512-0CaZnXKBw2pwnIbvmVckby5Ge5e2ecmjofhYCdyeACbCly2j3WXDP/pl+s+Dqd2GQFC7y99NB+53jrt55CKxYQ==",
       "dev": true,
       "requires": {
@@ -14686,13 +14691,13 @@
       "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
       "requires": {
         "sax": "0.5.8",
-        "xmlbuilder": "10.0.0"
+        "xmlbuilder": "10.1.1"
       }
     },
     "xmlbuilder": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.0.0.tgz",
-      "integrity": "sha512-7RWHlmF1yU/E++BZkRQTEv8ZFAhZ+YHINUAxiZ5LQTKRQq//igpiY8rh7dJqPzgb/IzeC5jH9P7OaCERfM9DwA=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "query-string": "^6.2.0",
     "superagent": "^3.8.3",
     "murmurhash-js": "^1.0.0",
-    "strip-json-comments": "^2.0.1"
+    "strip-json-comments": "^2.0.1",
+    "xmlbuilder": "^10.1.1"
   },
   "devDependencies": {
     "@types/app-root-path": "^1.2.4",
@@ -33,6 +34,7 @@
     "@types/node": "^10.11.7",
     "@types/power-assert": "^1.5.0",
     "@types/handlebars": "^4.0.39",
+    "@types/xmlbuilder": "^0.0.34",
     "axios-mock-adapter": "^1.15.0",
     "codecov": "^3.1.0",
     "copyfiles": "^2.1.0",

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -6,6 +6,7 @@ import {
 import {BitbucketProjectAccessCommand} from "./gluon/commands/bitbucket/BitbucketProjectAccessCommand";
 import {BitbucketProjectRecommendedPracticesCommand} from "./gluon/commands/bitbucket/BitbucketProjectRecommendedPracticesCommand";
 import {KickOffJenkinsBuild} from "./gluon/commands/jenkins/JenkinsBuild";
+import {JenkinsCredentialsRecreate} from "./gluon/commands/jenkins/JenkinsCredentialsRecreate";
 import {AddSlackDetails} from "./gluon/commands/member/AddSlackDetails";
 import {OnboardMember} from "./gluon/commands/member/OnboardMember";
 import {ConfigureBasicPackage} from "./gluon/commands/packages/ConfigureBasicPackage";
@@ -126,6 +127,7 @@ export const configuration: any = {
         CreateProjectProdEnvironments,
         CreateTeam,
         JoinTeam,
+        JenkinsCredentialsRecreate,
         KickOffJenkinsBuild,
         LinkExistingApplication,
         LinkExistingLibrary,

--- a/src/gluon/commands/jenkins/JenkinsCredentialsRecreate.ts
+++ b/src/gluon/commands/jenkins/JenkinsCredentialsRecreate.ts
@@ -1,0 +1,95 @@
+import {
+    CommandHandler,
+    HandlerContext,
+    HandlerResult,
+    logger,
+    MappedParameter,
+    MappedParameters,
+} from "@atomist/automation-client";
+import {QMConfig} from "../../../config/QMConfig";
+import {isSuccessCode} from "../../../http/Http";
+import {GluonService} from "../../services/gluon/GluonService";
+import {JenkinsService} from "../../services/jenkins/JenkinsService";
+import {OCService} from "../../services/openshift/OCService";
+import {getJenkinsBitbucketAccessCredentialXML} from "../../util/jenkins/JenkinsCredentials";
+import {
+    GluonTeamNameSetter,
+    setGluonTeamName,
+} from "../../util/recursiveparam/GluonParameterSetters";
+import {
+    RecursiveParameter,
+    RecursiveParameterRequestCommand,
+} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
+import {
+    handleQMError,
+    QMError,
+    ResponderMessageClient,
+} from "../../util/shared/Error";
+import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
+
+@CommandHandler("Recreate the Jenkins Bitbucket Credentials", QMConfig.subatomic.commandPrefix + " create jenkins bitbucket credentials")
+export class JenkinsCredentialsRecreate extends RecursiveParameterRequestCommand
+    implements GluonTeamNameSetter {
+
+    private static RecursiveKeys = {
+        teamName: "TEAM_NAME",
+    };
+
+    @MappedParameter(MappedParameters.SlackUser)
+    public slackName: string;
+
+    @MappedParameter(MappedParameters.SlackUserName)
+    public screenName: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public teamChannel: string;
+
+    @RecursiveParameter({
+        recursiveKey: JenkinsCredentialsRecreate.RecursiveKeys.teamName,
+        selectionMessage: "Please select the team which contains the owning project of the jenkins you would like to reconfigure",
+    })
+    public teamName: string;
+
+    constructor(public gluonService = new GluonService(),
+                private jenkinsService = new JenkinsService(),
+                private ocService = new OCService()) {
+        super();
+    }
+
+    protected async runCommand(ctx: HandlerContext) {
+        try {
+            await this.ocService.login();
+            return await this.recreateBitbucketJenkinsCredential(ctx, this.teamName);
+        } catch (error) {
+            return await handleQMError(new ResponderMessageClient(ctx), error);
+        }
+    }
+
+    protected configureParameterSetters() {
+        this.addRecursiveSetter(JenkinsCredentialsRecreate.RecursiveKeys.teamName, setGluonTeamName);
+    }
+
+    private async recreateBitbucketJenkinsCredential(ctx: HandlerContext,
+                                                     gluonTeamName: string): Promise<HandlerResult> {
+
+        const teamDevOpsProjectId = getDevOpsEnvironmentDetails(gluonTeamName).openshiftProjectId;
+        const token = await this.ocService.getServiceAccountToken("subatomic-jenkins", teamDevOpsProjectId);
+
+        const jenkinsHost = await this.ocService.getJenkinsHost(teamDevOpsProjectId);
+
+        logger.debug(`Using Jenkins Route host [${jenkinsHost.output}] to kick off build`);
+
+        const kickOffBuildResult = await this.jenkinsService.updateGlobalCredential(
+            jenkinsHost.output,
+            token,
+            getJenkinsBitbucketAccessCredentialXML(teamDevOpsProjectId),
+            `${teamDevOpsProjectId}-bitbucket`,
+        );
+        if (!isSuccessCode(kickOffBuildResult.status)) {
+            throw new QMError("Failed to recreate the Jenkins Bitbucket Credential! Please ensure your Jenkins is running.");
+        }
+        return await ctx.messageClient.respond({
+            text: `🚀 Successfully created the Jenkins Bitbucket Credentials for *${gluonTeamName}* DevOps.`,
+        });
+    }
+}

--- a/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
+++ b/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
@@ -5,6 +5,7 @@ import {isSuccessCode} from "../../../http/Http";
 import {QMTemplate} from "../../../template/QMTemplate";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
 import {OCService} from "../../services/openshift/OCService";
+import {getJenkinsBitbucketAccessCredential} from "../../util/jenkins/JenkinsCredentials";
 import {getProjectId} from "../../util/project/Project";
 import {QMError} from "../../util/shared/Error";
 import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
@@ -100,17 +101,7 @@ export class ConfigureJenkinsForProject extends Task {
 
     private async createJenkinsCredentials(teamDevOpsProjectId: string, jenkinsHost: string, token: string) {
 
-        const jenkinsCredentials = {
-            "": "0",
-            "credentials": {
-                scope: "GLOBAL",
-                id: `${teamDevOpsProjectId}-bitbucket`,
-                username: QMConfig.subatomic.bitbucket.auth.username,
-                password: QMConfig.subatomic.bitbucket.auth.password,
-                description: `${teamDevOpsProjectId}-bitbucket`,
-                $class: "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
-            },
-        };
+        const jenkinsCredentials = getJenkinsBitbucketAccessCredential(teamDevOpsProjectId);
 
         await this.jenkinsService.createJenkinsCredentialsWithRetries(6, 5000, jenkinsHost, token, teamDevOpsProjectId, jenkinsCredentials);
     }

--- a/src/gluon/util/jenkins/JenkinsCredentials.ts
+++ b/src/gluon/util/jenkins/JenkinsCredentials.ts
@@ -1,0 +1,85 @@
+import {logger} from "@atomist/automation-client";
+import * as XmlBuilder from "xmlbuilder";
+import {QMConfig} from "../../../config/QMConfig";
+
+export function getJenkinsBitbucketAccessCredential(teamDevOpsProjectId: string) {
+    return {
+        "": "0",
+        "credentials": {
+            scope: "GLOBAL",
+            id: `${teamDevOpsProjectId}-bitbucket`,
+            username: QMConfig.subatomic.bitbucket.auth.username,
+            password: QMConfig.subatomic.bitbucket.auth.password,
+            description: `${teamDevOpsProjectId}-bitbucket`,
+            $class: "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
+        },
+    };
+}
+
+export function getJenkinsBitbucketAccessCredentialXML(teamDevOpsProjectId) {
+    const value = XmlBuilder.begin()
+        .ele("com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl", {plugin: "credentials@2.1.18"})
+        .ele("scope", "GLOBAL").up()
+        .ele("id", `${teamDevOpsProjectId}-bitbucket`).up()
+        .ele("description", `${teamDevOpsProjectId}-bitbucket`).up()
+        .ele("username", `${QMConfig.subatomic.bitbucket.auth.username}`).up()
+        .ele("password", `${QMConfig.subatomic.bitbucket.auth.password}`).up()
+        .end({pretty: true});
+
+    logger.debug("Built XML Credential: \n" + value);
+    return value;
+}
+
+export function getJenkinsBitbucketProjectCredential(projectId: string) {
+    return {
+        "": "0",
+        "credentials": {
+            scope: "GLOBAL",
+            id: `${projectId}-bitbucket`,
+            username: QMConfig.subatomic.bitbucket.auth.username,
+            password: QMConfig.subatomic.bitbucket.auth.password,
+            description: `${projectId}-bitbucket`,
+            $class: "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
+        },
+    };
+}
+
+export function getJenkinsNexusCredential() {
+    return {
+        "": "0",
+        "credentials": {
+            scope: "GLOBAL",
+            id: "nexus-base-url",
+            secret: `${QMConfig.subatomic.nexus.baseUrl}/content/repositories/`,
+            description: "Nexus base URL",
+            $class: "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl",
+        },
+    };
+}
+
+export function getJenkinsDockerCredential() {
+    return {
+        "": "0",
+        "credentials": {
+            scope: "GLOBAL",
+            id: "docker-registry-ip",
+            secret: `${QMConfig.subatomic.openshiftNonProd.dockerRepoUrl}`,
+            description: "IP For internal docker registry",
+            $class: "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl",
+        },
+    };
+}
+
+export function getJenkinsMavenCredential() {
+    return {
+        "": "0",
+        "credentials": {
+            scope: "GLOBAL",
+            id: "maven-settings",
+            file: "file",
+            fileName: "settings.xml",
+            description: "Maven settings.xml",
+            $class: "org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl",
+        },
+    };
+}


### PR DESCRIPTION
Added the command `sub create jenkins bitbucket credentials` which will overwrite the existing bitbucket credentials in a Jenkins instance.

Additionally cleaned up some of the implementation around Jenkins operations.

Closes #474 