### PR TITLE
Display FAQ message with extra formatting

### DIFF
--- a/test/gluon/commands/team/CreateTeamTest.ts
+++ b/test/gluon/commands/team/CreateTeamTest.ts
@@ -90,6 +90,6 @@ describe("Create Team test", () => {
         };
 
         await subject.runCommand(fakeContext);
-        assert(fakeContext.messageClient.textMsg[0].text === `❗Failed to create team since the team name is already in use. Please retry using a different team name. ${url(`${QMConfig.subatomic.docs.baseUrl}/FAQ`, "FAQ")}`);
+        assert(fakeContext.messageClient.textMsg[0].text === `❗Failed to create team since the team name is already in use. Please retry using a different team name. Consulting the ${url(`${QMConfig.subatomic.docs.baseUrl}/FAQ`, "FAQ")} may be useful.`);
     });
 });

--- a/test/gluon/services/team/AddMemberToTeamServiceTest.ts
+++ b/test/gluon/services/team/AddMemberToTeamServiceTest.ts
@@ -59,7 +59,7 @@ describe("AddMemberToTeamService addUserToGluonTeam", () => {
             errorThrown = error;
         }
 
-        assert.equal(errorThrown.getSlackMessage().text, `❗Failed to add member to the team. Server side failure. ${url(`${QMConfig.subatomic.docs.baseUrl}/FAQ`, "FAQ")}`);
+        assert.equal(errorThrown.getSlackMessage().text, `❗Failed to add member to the team. Server side failure. Consulting the ${url(`${QMConfig.subatomic.docs.baseUrl}/FAQ`, "FAQ")} may be useful.`);
 
     });
 
@@ -97,7 +97,10 @@ describe("AddMemberToTeamService inviteUserToSlackChannel", () => {
         };
 
         // Force invite to fail
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "1234"}]}});
+        fakeContext.graphClient.executeQueryResults.push({
+            result: true,
+            returnValue: {ChatTeam: [{id: "1234"}]},
+        });
         fakeContext.graphClient.executeMutationResults.push({result: false});
 
         await service.inviteUserToSlackChannel(fakeContext,
@@ -126,7 +129,10 @@ describe("AddMemberToTeamService inviteUserToSlackChannel", () => {
             graphClient: new TestGraphClient(),
         };
 
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "1234"}]}});
+        fakeContext.graphClient.executeQueryResults.push({
+            result: true,
+            returnValue: {ChatTeam: [{id: "1234"}]},
+        });
 
         await service.inviteUserToSlackChannel(fakeContext,
             "Jude",


### PR DESCRIPTION
Now does the follow when appending FAQ link to error messages:
 - Looks at the error message and adds punctation as neccessary
 - Also adds the FAQ link to messages of type SlackMessage instead of just string messages.