### PR TITLE
Migrate OpenShift Cloud

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -36,6 +36,7 @@ import {NewDevOpsEnvironment} from "./gluon/commands/team/DevOpsEnvironment";
 import {JoinTeam} from "./gluon/commands/team/JoinTeam";
 import {LinkExistingTeamSlackChannel} from "./gluon/commands/team/LinkExistingTeamSlackChannel";
 import {ListTeamMembers} from "./gluon/commands/team/ListTeamMembers";
+import {MigrateTeamCloud} from "./gluon/commands/team/MigrateTeamCloud";
 import {NewOrUseTeamSlackChannel} from "./gluon/commands/team/NewOrExistingTeamSlackChannel";
 import {NewTeamSlackChannel} from "./gluon/commands/team/NewSlackChannel";
 import {RemoveMemberFromTeam} from "./gluon/commands/team/RemoveMemberFromTeam";
@@ -98,6 +99,7 @@ export const configuration: any = {
         ListTeamMembers,
         ListTeamProjects,
         MembershipRequestClosed,
+        MigrateTeamCloud,
         NewDevOpsEnvironment,
         NewOrUseTeamSlackChannel,
         NewProjectEnvironments,

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -59,6 +59,7 @@ import {MembersAddedToTeam} from "./gluon/events/team/MembersAddedToTeam";
 import {MembershipRequestClosed} from "./gluon/events/team/MembershipRequestClosed";
 import {MembershipRequestCreated} from "./gluon/events/team/MembershipRequestCreated";
 import {TeamCreated} from "./gluon/events/team/TeamCreated";
+import {TeamOpenShiftCloudMigrated} from "./gluon/events/team/TeamOpenShiftCloudMigrated";
 import {PrometheusClient} from "./gluon/metrics/prometheus/PrometheusClient";
 
 const apiKey = QMConfig.apiKey;
@@ -129,6 +130,7 @@ export const configuration: any = {
         TeamCreated,
         TeamMemberCreated,
         TeamsLinkedToProject,
+        TeamOpenShiftCloudMigrated,
     ],
     ingesters: [
         ingester("TeamDevOpsDetails"),
@@ -156,6 +158,7 @@ export const configuration: any = {
         ingester("TeamCreatedEvent"),
         ingester("DevOpsEnvironmentRequestedEvent"),
         ingester("DevOpsEnvironmentProvisionedEvent"),
+        ingester("TeamOpenShiftCloudMigratedEvent"),
         ingester("MembershipRequestCreatedEvent"),
         ingester("MembersAddedToTeamEvent"),
         ingester("MemberRemovedFromTeamEvent"),

--- a/src/gluon/commands/help/HelpCategory.ts
+++ b/src/gluon/commands/help/HelpCategory.ts
@@ -1,8 +1,6 @@
 import * as _ from "lodash";
 import {MembershipRequestClosed} from "../../events/team/MembershipRequestClosed";
-import {
-    ListExistingBitbucketProject,
-} from "../bitbucket/BitbucketProject";
+import {ListExistingBitbucketProject} from "../bitbucket/BitbucketProject";
 import {BitbucketProjectAccessCommand} from "../bitbucket/BitbucketProjectAccessCommand";
 import {BitbucketProjectRecommendedPracticesCommand} from "../bitbucket/BitbucketProjectRecommendedPracticesCommand";
 import {KickOffJenkinsBuild} from "../jenkins/JenkinsBuild";
@@ -22,10 +20,7 @@ import {CreateOpenShiftPvc} from "../project/CreateOpenShiftPvc";
 import {CreateProject} from "../project/CreateProject";
 import {CreateProjectProdEnvironments} from "../project/CreateProjectProdEnvironments";
 import {NewProjectEnvironments} from "../project/NewProjectEnvironments";
-import {
-    ListProjectDetails,
-    ListTeamProjects,
-} from "../project/ProjectDetails";
+import {ListProjectDetails, ListTeamProjects} from "../project/ProjectDetails";
 import {ReRunProjectProdRequest} from "../project/ReRunProjectProdRequest";
 import {UpdateProjectProdRequest} from "../project/UpdateProjectProdRequest";
 import {AddConfigServer} from "../team/AddConfigServer";
@@ -37,6 +32,7 @@ import {NewDevOpsEnvironment} from "../team/DevOpsEnvironment";
 import {JoinTeam} from "../team/JoinTeam";
 import {LinkExistingTeamSlackChannel} from "../team/LinkExistingTeamSlackChannel";
 import {ListTeamMembers} from "../team/ListTeamMembers";
+import {MigrateTeamCloud} from "../team/MigrateTeamCloud";
 import {NewOrUseTeamSlackChannel} from "../team/NewOrExistingTeamSlackChannel";
 import {NewTeamSlackChannel} from "../team/NewSlackChannel";
 import {RemoveMemberFromTeam} from "../team/RemoveMemberFromTeam";
@@ -75,6 +71,7 @@ export class HelpCategory {
         ListTeamMembers,
         ListTeamProjects,
         MembershipRequestClosed,
+        MigrateTeamCloud,
         NewDevOpsEnvironment,
         NewOrUseTeamSlackChannel,
         NewProjectEnvironments,

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -1,0 +1,216 @@
+import {
+    buttonForCommand,
+    HandlerContext,
+    HandlerResult,
+    Parameter,
+    success,
+    Tags,
+} from "@atomist/automation-client";
+import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {SlackMessage} from "@atomist/slack-messages";
+import {v4 as uuid} from "uuid";
+import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
+import {QMConfig} from "../../../config/QMConfig";
+import {GluonService} from "../../services/gluon/GluonService";
+import {OCService} from "../../services/openshift/OCService";
+import {ConfigureJenkinsForProject} from "../../tasks/project/ConfigureJenkinsForProject";
+import {CreateOpenshiftEnvironments} from "../../tasks/project/CreateOpenshiftEnvironments";
+import {CreateOpenshiftResourcesInProject} from "../../tasks/project/CreateOpenshiftResourcesInProject";
+import {TaskListMessage} from "../../tasks/TaskListMessage";
+import {TaskRunner} from "../../tasks/TaskRunner";
+import {CreateTeamDevOpsEnvironment} from "../../tasks/team/CreateTeamDevOpsEnvironment";
+import {
+    getAllProjectOpenshiftNamespaces,
+    OpenshiftProjectEnvironmentRequest,
+    OpenShiftProjectNamespace,
+    QMProject,
+} from "../../util/project/Project";
+import {QMColours} from "../../util/QMColour";
+import {
+    GluonTeamNameParam,
+    GluonTeamNameSetter,
+    GluonTeamOpenShiftCloudParam,
+} from "../../util/recursiveparam/GluonParameterSetters";
+import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
+import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
+import {
+    ChannelMessageClient,
+    handleQMError,
+    QMMessageClient,
+    ResponderMessageClient,
+} from "../../util/shared/Error";
+import {QMTenant} from "../../util/shared/Tenants";
+import {QMTeam} from "../../util/team/Teams";
+
+@CommandHandler("Move openshift resources to a different cloud", QMConfig.subatomic.commandPrefix + " team cloud migrate")
+@Tags("subatomic", "team", "other")
+export class MigrateTeamCloud extends RecursiveParameterRequestCommand
+    implements GluonTeamNameSetter {
+
+    @GluonTeamNameParam({
+        callOrder: 0,
+        selectionMessage: "Please select a team associated with the project you wish to configure the package for",
+    })
+    public teamName: string;
+
+    @GluonTeamOpenShiftCloudParam({
+        callOrder: 1,
+    })
+    public openShiftCloud: string;
+
+    @Parameter({
+        required: false,
+        displayable: false,
+    })
+    public approval: ApprovalEnum = ApprovalEnum.CONFIRM;
+
+    @Parameter({
+        required: false,
+        displayable: false,
+    })
+    public correlationId: string;
+
+    @Parameter({
+        required: false,
+        displayable: false,
+    })
+    public openShiftResourcesJSON: string;
+
+    constructor(public gluonService = new GluonService(), public ocService = new OCService()) {
+        super();
+    }
+
+    protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
+        try {
+            const team: QMTeam = await this.gluonService.teams.gluonTeamByName(this.teamName);
+            const qmMessageClient = new ChannelMessageClient(ctx).addDestination(team.slack.teamChannel);
+
+            if (this.approval === ApprovalEnum.CONFIRM) {
+                this.correlationId = uuid();
+                const message = this.confirmMigrationRequest(this);
+
+                return await qmMessageClient.send(message, {id: this.correlationId});
+            } else if (this.approval === ApprovalEnum.APPROVED) {
+
+                const taskRunner = await this.createMigrateTeamToCloudTasks(qmMessageClient, team);
+
+                await taskRunner.execute(ctx);
+
+                this.succeedCommand();
+
+                return success();
+            } else if (this.approval === ApprovalEnum.REJECTED) {
+                return await qmMessageClient.send(this.getConfirmationResultMesssage(this.approval), {id: this.correlationId});
+            }
+
+        } catch (error) {
+            this.failCommand();
+            return await handleQMError(new ResponderMessageClient(ctx), error);
+        }
+    }
+
+    private getConfirmationResultMesssage(result: ApprovalEnum) {
+        const message = {
+            text: `*Migration request status:*`,
+            attachments: [],
+        };
+
+        if (result === ApprovalEnum.APPROVED) {
+            message.attachments.push({
+                text: `*Confirmed*`,
+                fallback: "*Confirmed*",
+                color: QMColours.stdGreenyMcAppleStroodle.hex,
+            });
+        } else if (result === ApprovalEnum.REJECTED) {
+            message.attachments.push({
+                text: `*Cancelled*`,
+                fallback: "*Cancelled*",
+                color: QMColours.stdReddyMcRedFace.hex,
+            });
+        }
+
+        return message;
+    }
+
+    private async createMigrateTeamToCloudTasks(qmMessageClient: QMMessageClient, team: QMTeam) {
+        const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Migrating Team to cloud *${this.openShiftCloud}* started:`,
+            qmMessageClient);
+        const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
+
+        taskRunner.addTask(
+            new CreateTeamDevOpsEnvironment({team}, QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd),
+        );
+
+        const projects = await this.gluonService.projects.gluonProjectsWhichBelongToGluonTeam(team.name, false);
+        for (const project of projects) {
+            await this.addCreateProjectEnvironmentsTasks(taskRunner, team, project);
+        }
+
+        return taskRunner;
+    }
+
+    private async addCreateProjectEnvironmentsTasks(taskRunner: TaskRunner, team: QMTeam, project: QMProject) {
+
+        const tenant: QMTenant = await this.gluonService.tenants.gluonTenantFromTenantId(project.owningTenant);
+
+        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd);
+
+        const environmentsForCreation: OpenShiftProjectNamespace[] = getAllProjectOpenshiftNamespaces(tenant, project);
+
+        const createOpenshiftEnvironmentsDetails: OpenshiftProjectEnvironmentRequest = {
+            project,
+            owningTenant: tenant,
+            teams: [team],
+        };
+
+        const openShiftNonProd: OpenShiftConfig = QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd;
+
+        taskRunner.addTask(
+            new CreateOpenshiftEnvironments(createOpenshiftEnvironmentsDetails, environmentsForCreation, openShiftNonProd),
+        ).addTask(
+            new ConfigureJenkinsForProject(createOpenshiftEnvironmentsDetails, project.devDeploymentPipeline, project.releaseDeploymentPipelines, openShiftNonProd),
+        );
+
+        const resourceKindsForExport = ["Service", "DeploymentConfig", "ImageStream", "Route", "PersistentVolumeClaim", "Secret", "ConfigMap"];
+
+        for (const environment of environmentsForCreation) {
+            const allResources = await this.ocService.exportAllResources(environment.namespace, resourceKindsForExport);
+            taskRunner.addTask(
+                new CreateOpenshiftResourcesInProject([environment], environment.namespace, allResources, openShiftNonProd),
+            );
+        }
+    }
+
+    private confirmMigrationRequest(migrationRequestCommand: MigrateTeamCloud): SlackMessage {
+
+        const text: string = `By clicking Approve below you confirm that you sign off on the team and all associated resources being moved to the selected cloud.`;
+
+        return {
+            text,
+            attachments: [{
+                fallback: "Please confirm that the above resources should be moved to Prod",
+                footer: `For more information, please read the docs.`,
+                thumb_url: "https://raw.githubusercontent.com/absa-subatomic/subatomic-documentation/gh-pages/images/subatomic-logo-colour.png",
+                actions: [
+                    buttonForCommand(
+                        {
+                            text: "Approve Migration Request",
+                            style: "primary",
+                        },
+                        migrationRequestCommand,
+                        {
+                            approval: ApprovalEnum.APPROVED,
+                        }),
+                    buttonForCommand(
+                        {
+                            text: "Cancel Migration Request",
+                        },
+                        migrationRequestCommand,
+                        {
+                            approval: ApprovalEnum.REJECTED,
+                        }),
+                ],
+            }],
+        };
+    }
+}

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -17,9 +17,13 @@ import {QMColours} from "../../util/QMColour";
 import {
     GluonTeamNameParam,
     GluonTeamNameSetter,
-    GluonTeamOpenShiftCloudParam,
+    GluonTeamOpenShiftCloudBaseSetter,
+    setGluonTeamOpenShiftCloudForced,
 } from "../../util/recursiveparam/GluonParameterSetters";
-import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
+import {
+    RecursiveParameter,
+    RecursiveParameterRequestCommand,
+} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
 import {
     ChannelMessageClient,
@@ -31,7 +35,7 @@ import {QMTeam} from "../../util/team/Teams";
 @CommandHandler("Move all Openshift resources belonging to a team to a different cloud", QMConfig.subatomic.commandPrefix + " team migrate cloud")
 @Tags("subatomic", "team", "other")
 export class MigrateTeamCloud extends RecursiveParameterRequestCommand
-    implements GluonTeamNameSetter {
+    implements GluonTeamNameSetter, GluonTeamOpenShiftCloudBaseSetter {
 
     @GluonTeamNameParam({
         callOrder: 0,
@@ -39,8 +43,9 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
     })
     public teamName: string;
 
-    @GluonTeamOpenShiftCloudParam({
+    @RecursiveParameter({
         callOrder: 1,
+        setter: setGluonTeamOpenShiftCloudForced,
     })
     public openShiftCloud: string;
 
@@ -55,12 +60,6 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
         displayable: false,
     })
     public correlationId: string;
-
-    @Parameter({
-        required: false,
-        displayable: false,
-    })
-    public openShiftResourcesJSON: string;
 
     constructor(public gluonService = new GluonService(), public ocService = new OCService()) {
         super();

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -21,6 +21,7 @@ import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
 import {AddJenkinsToDevOpsEnvironment} from "../../tasks/team/AddJenkinsToDevOpsEnvironment";
 import {CreateTeamDevOpsEnvironment} from "../../tasks/team/CreateTeamDevOpsEnvironment";
+import {QMMemberBase} from "../../util/member/Members";
 import {
     getAllProjectOpenshiftNamespaces,
     OpenshiftProjectEnvironmentRequest,
@@ -93,6 +94,10 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
 
                 return await qmMessageClient.send(message, {id: this.correlationId});
             } else if (this.approval === ApprovalEnum.APPROVED) {
+
+                const requestingMember: QMMemberBase = await this.gluonService.members.gluonMemberFromScreenName(this.screenName);
+
+                await this.gluonService.teams.updateTeamOpenShiftCloud(team.teamId, this.openShiftCloud, requestingMember.memberId);
 
                 const taskRunner = await this.createMigrateTeamToCloudTasks(qmMessageClient, team);
 

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -3,31 +3,16 @@ import {
     HandlerContext,
     HandlerResult,
     Parameter,
+    success,
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {SlackMessage} from "@atomist/slack-messages";
 import {v4 as uuid} from "uuid";
-import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
-import {QMApplication} from "../../services/gluon/ApplicationService";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
-import {ConfigurePackageInJenkins} from "../../tasks/packages/ConfigurePackageInJenkins";
-import {ConfigureJenkinsForProject} from "../../tasks/project/ConfigureJenkinsForProject";
-import {CreateOpenshiftEnvironments} from "../../tasks/project/CreateOpenshiftEnvironments";
-import {CreateOpenshiftResourcesInProject} from "../../tasks/project/CreateOpenshiftResourcesInProject";
-import {TaskListMessage} from "../../tasks/TaskListMessage";
-import {TaskRunner} from "../../tasks/TaskRunner";
-import {AddJenkinsToDevOpsEnvironment} from "../../tasks/team/AddJenkinsToDevOpsEnvironment";
-import {CreateTeamDevOpsEnvironment} from "../../tasks/team/CreateTeamDevOpsEnvironment";
 import {QMMemberBase} from "../../util/member/Members";
-import {
-    getAllProjectOpenshiftNamespaces,
-    OpenshiftProjectEnvironmentRequest,
-    OpenShiftProjectNamespace,
-    QMProject,
-} from "../../util/project/Project";
 import {QMColours} from "../../util/QMColour";
 import {
     GluonTeamNameParam,
@@ -39,10 +24,8 @@ import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
 import {
     ChannelMessageClient,
     handleQMError,
-    QMMessageClient,
     ResponderMessageClient,
 } from "../../util/shared/Error";
-import {QMTenant} from "../../util/shared/Tenants";
 import {QMTeam} from "../../util/team/Teams";
 
 @CommandHandler("Move openshift resources to a different cloud", QMConfig.subatomic.commandPrefix + " team cloud migrate")
@@ -99,13 +82,9 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
 
                 await this.gluonService.teams.updateTeamOpenShiftCloud(team.teamId, this.openShiftCloud, requestingMember.memberId);
 
-                const taskRunner = await this.createMigrateTeamToCloudTasks(qmMessageClient, team);
-
-                await taskRunner.execute(ctx);
-
                 this.succeedCommand();
 
-                return qmMessageClient.send(`:rocket: Team successfully migrated to "${this.openShiftCloud}" cloud.`);
+                return success();
             } else if (this.approval === ApprovalEnum.REJECTED) {
                 return await qmMessageClient.send(this.getConfirmationResultMessage(this.approval), {id: this.correlationId});
             }
@@ -139,66 +118,6 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
         return message;
     }
 
-    private async createMigrateTeamToCloudTasks(qmMessageClient: QMMessageClient, team: QMTeam) {
-        const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Migrating Team to cloud *${this.openShiftCloud}* started:`,
-            qmMessageClient);
-        const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
-
-        taskRunner.addTask(
-            new CreateTeamDevOpsEnvironment(team, QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd),
-        ).addTask(
-            new AddJenkinsToDevOpsEnvironment(team),
-        );
-
-        const projects = await this.gluonService.projects.gluonProjectsWhichBelongToGluonTeam(team.name, false);
-        for (const project of projects) {
-            await this.addCreateProjectEnvironmentsTasks(taskRunner, team, project);
-        }
-
-        return taskRunner;
-    }
-
-    private async addCreateProjectEnvironmentsTasks(taskRunner: TaskRunner, team: QMTeam, project: QMProject) {
-
-        const tenant: QMTenant = await this.gluonService.tenants.gluonTenantFromTenantId(project.owningTenant);
-
-        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd);
-
-        const environmentsForCreation: OpenShiftProjectNamespace[] = getAllProjectOpenshiftNamespaces(tenant, project);
-
-        const createOpenshiftEnvironmentsDetails: OpenshiftProjectEnvironmentRequest = {
-            project,
-            owningTenant: tenant,
-            teams: [team],
-        };
-
-        const openShiftNonProd: OpenShiftConfig = QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd;
-
-        taskRunner.addTask(
-            new CreateOpenshiftEnvironments(createOpenshiftEnvironmentsDetails, environmentsForCreation, openShiftNonProd),
-        ).addTask(
-            new ConfigureJenkinsForProject(createOpenshiftEnvironmentsDetails, project.devDeploymentPipeline, project.releaseDeploymentPipelines, openShiftNonProd),
-        );
-
-        const resourceKindsForExport = ["Service", "DeploymentConfig", "ImageStream", "Route", "PersistentVolumeClaim", "Secret", "ConfigMap"];
-
-        for (const environment of environmentsForCreation) {
-            // const allResources = await this.ocService.exportAllResources(environment.namespace, resourceKindsForExport);
-            const allResources = this.getAllResources();
-            taskRunner.addTask(
-                new CreateOpenshiftResourcesInProject([environment], environment.namespace, allResources, openShiftNonProd),
-                undefined,
-                0,
-            );
-        }
-
-        const applications: QMApplication[] = await this.gluonService.applications.gluonApplicationsLinkedToGluonProject(project.name, false);
-
-        for (const application of applications) {
-            taskRunner.addTask(new ConfigurePackageInJenkins(application, project), `*Create ${application.name} application Jenkins job*`);
-        }
-    }
-
     private confirmMigrationRequest(migrationRequestCommand: MigrateTeamCloud): SlackMessage {
 
         const text: string = `By clicking Approve below you confirm that you sign off on the team and all associated resources being moved to the selected cloud.`;
@@ -229,225 +148,6 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
                         }),
                 ],
             }],
-        };
-    }
-
-    private getAllResources() {
-        return {
-            kind: "List",
-            apiVersion: "v1",
-            metadata: {},
-            items: [
-                {
-                    metadata: {
-                        name: "hello-world",
-                        namespace: "default-demo-dev",
-                        selfLink: "/api/v1/namespaces/default-demo-dev/services/hello-world",
-                        uid: "5a6d3daa-1336-11e9-876b-3a7727ae98a4",
-                        resourceVersion: "468878",
-                        creationTimestamp: "2019-01-08T11:12:57Z",
-                        labels: {
-                            app: "hello-world",
-                            template: "subatomic-spring-boot-2x-template",
-                        },
-                    },
-                    spec: {
-                        ports: [
-                            {
-                                name: "web",
-                                protocol: "TCP",
-                                port: 8080,
-                                targetPort: "http-8080",
-                            },
-                        ],
-                        selector: {
-                            name: "hello-world",
-                        },
-                        clusterIP: "172.30.169.116",
-                        type: "ClusterIP",
-                        sessionAffinity: "None",
-                    },
-                    status: {
-                        loadBalancer: {},
-                    },
-                    kind: "Service",
-                    apiVersion: "v1",
-                },
-                {
-                    metadata: {
-                        name: "hello-world",
-                        namespace: "default-demo-dev",
-                        selfLink: "/oapi/v1/namespaces/default-demo-dev/deploymentconfigs/hello-world",
-                        uid: "5a66d50e-1336-11e9-a9e2-3a7727ae98a4",
-                        resourceVersion: "468882",
-                        generation: 1,
-                        creationTimestamp: "2019-01-08T11:12:57Z",
-                        labels: {
-                            template: "subatomic-spring-boot-2x-template",
-                        },
-                    },
-                    spec: {
-                        strategy: {
-                            type: "Rolling",
-                            rollingParams: {
-                                updatePeriodSeconds: 1,
-                                intervalSeconds: 1,
-                                timeoutSeconds: 600,
-                                maxUnavailable: "25%",
-                                maxSurge: "25%",
-                            },
-                            resources: {},
-                            activeDeadlineSeconds: 21600,
-                        },
-                        triggers: [
-                            {
-                                type: "ImageChange",
-                                imageChangeParams: {
-                                    automatic: true,
-                                    containerNames: [
-                                        "hello-world",
-                                    ],
-                                    from: {
-                                        kind: "ImageStreamTag",
-                                        namespace: "default-demo-dev",
-                                        name: "hello-world:latest",
-                                    },
-                                },
-                            },
-                            {
-                                type: "ConfigChange",
-                            },
-                        ],
-                        replicas: 1,
-                        revisionHistoryLimit: 2,
-                        test: false,
-                        selector: {
-                            name: "hello-world",
-                        },
-                        template: {
-                            metadata: {
-                                creationTimestamp: null,
-                                labels: {
-                                    name: "hello-world",
-                                },
-                            },
-                            spec: {
-                                containers: [
-                                    {
-                                        name: "hello-world",
-                                        image: " ",
-                                        ports: [
-                                            {
-                                                name: "http-8080",
-                                                containerPort: 8080,
-                                                protocol: "TCP",
-                                            },
-                                        ],
-                                        env: [
-                                            {
-                                                name: "SPRING_CLOUD_CONFIG_URI",
-                                                value: "http://subatomic-config-server.test-team-devops.svc.cluster.local",
-                                            },
-                                            {
-                                                name: "JAVA_MAX_CORE",
-                                                value: "4",
-                                            },
-                                            {
-                                                name: "JAVA_OPTIONS",
-                                                value: "-Djava.net.preferIPv4Stack=true -Djava.security.egd=file:/dev/./urandom",
-                                            },
-                                        ],
-                                        resources: {
-                                            limits: {
-                                                cpu: "4",
-                                                memory: "1Gi",
-                                            },
-                                            requests: {
-                                                cpu: "0",
-                                                memory: "0",
-                                            },
-                                        },
-                                        livenessProbe: {
-                                            httpGet: {
-                                                path: "/actuator/health",
-                                                port: "http-8080",
-                                                scheme: "HTTP",
-                                            },
-                                            initialDelaySeconds: 30,
-                                            timeoutSeconds: 1,
-                                            periodSeconds: 10,
-                                            successThreshold: 1,
-                                            failureThreshold: 3,
-                                        },
-                                        readinessProbe: {
-                                            httpGet: {
-                                                path: "/actuator/info",
-                                                port: "http-8080",
-                                                scheme: "HTTP",
-                                            },
-                                            timeoutSeconds: 1,
-                                            periodSeconds: 10,
-                                            successThreshold: 1,
-                                            failureThreshold: 3,
-                                        },
-                                        terminationMessagePath: "/dev/termination-log",
-                                        terminationMessagePolicy: "File",
-                                        imagePullPolicy: "IfNotPresent",
-                                    },
-                                ],
-                                restartPolicy: "Always",
-                                terminationGracePeriodSeconds: 30,
-                                dnsPolicy: "ClusterFirst",
-                                securityContext: {},
-                                schedulerName: "default-scheduler",
-                            },
-                        },
-                    },
-                    status: {
-                        latestVersion: 0,
-                        observedGeneration: 1,
-                        replicas: 0,
-                        updatedReplicas: 0,
-                        availableReplicas: 0,
-                        unavailableReplicas: 0,
-                        conditions: [
-                            {
-                                type: "Available",
-                                status: "False",
-                                lastUpdateTime: "2019-01-08T11:12:57Z",
-                                lastTransitionTime: "2019-01-08T11:12:57Z",
-                                message: "Deployment config does not have minimum availability.",
-                            },
-                        ],
-                    },
-                    kind: "DeploymentConfig",
-                    apiVersion: "v1",
-                },
-                {
-                    metadata: {
-                        name: "hello-world",
-                        namespace: "default-demo-dev",
-                        selfLink: "/oapi/v1/namespaces/default-demo-dev/imagestreams/hello-world",
-                        uid: "5a61c1dc-1336-11e9-a9e2-3a7727ae98a4",
-                        resourceVersion: "468873",
-                        generation: 1,
-                        creationTimestamp: "2019-01-08T11:12:57Z",
-                        labels: {
-                            template: "subatomic-spring-boot-2x-template",
-                        },
-                    },
-                    spec: {
-                        lookupPolicy: {
-                            local: false,
-                        },
-                    },
-                    status: {
-                        dockerImageRepository: "172.30.1.1:5000/default-demo-dev/hello-world",
-                    },
-                    kind: "ImageStream",
-                    apiVersion: "v1",
-                },
-            ],
         };
     }
 }

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -28,7 +28,7 @@ import {
 } from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 
-@CommandHandler("Move openshift resources to a different cloud", QMConfig.subatomic.commandPrefix + " team cloud migrate")
+@CommandHandler("Move all Openshift resources belonging to a team to a different cloud", QMConfig.subatomic.commandPrefix + " team migrate cloud")
 @Tags("subatomic", "team", "other")
 export class MigrateTeamCloud extends RecursiveParameterRequestCommand
     implements GluonTeamNameSetter {

--- a/src/gluon/events/packages/ApplicationProdRequested.ts
+++ b/src/gluon/events/packages/ApplicationProdRequested.ts
@@ -114,7 +114,10 @@ export class ApplicationProdRequested extends BaseQMEvent implements HandleEvent
             const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
             for (const openshiftProd of QMConfig.subatomic.openshiftClouds[owningTeam.openShiftCloud].openshiftProd) {
                 const environmentsForCreation: OpenShiftProjectNamespace[] = getPipelineOpenShiftNamespacesForOpenShiftCluster(tenant.name, qmProject, applicationProdRequest.deploymentPipeline, openshiftProd);
-                taskRunner.addTask(new CreateOpenshiftResourcesInProject(environmentsForCreation, preProdNamespace, resources, openshiftProd));
+                taskRunner.addTask(
+                    new CreateOpenshiftResourcesInProject(environmentsForCreation, preProdNamespace, resources, openshiftProd),
+                    undefined,
+                    1);
             }
 
             await taskRunner.execute(ctx);

--- a/src/gluon/events/project/GenericProdRequested.ts
+++ b/src/gluon/events/project/GenericProdRequested.ts
@@ -77,7 +77,11 @@ export class GenericProdRequested extends BaseQMEvent implements HandleEvent<any
 
             for (const openshiftProd of QMConfig.subatomic.openshiftClouds[owningTeam.openShiftCloud].openshiftProd) {
                 const environmentsForResources: OpenShiftProjectNamespace[] = getPipelineOpenShiftNamespacesForOpenShiftCluster(tenant.name, qmProject, genericProdRequest.deploymentPipeline, openshiftProd);
-                taskRunner.addTask(new CreateOpenshiftResourcesInProject(environmentsForResources, preProdNamespace, resources, openshiftProd));
+                taskRunner.addTask(
+                    new CreateOpenshiftResourcesInProject(environmentsForResources, preProdNamespace, resources, openshiftProd),
+                    undefined,
+                    1,
+                );
             }
 
             await taskRunner.execute(ctx);

--- a/src/gluon/events/project/ProjectProductionEnvironmentsRequestClosed.ts
+++ b/src/gluon/events/project/ProjectProductionEnvironmentsRequestClosed.ts
@@ -82,7 +82,7 @@ export class ProjectProductionEnvironmentsRequestClosed extends BaseQMEvent impl
                     // Get details of all the prod project namespaces we need to operate on.
                     const environmentsForCreation: OpenShiftProjectNamespace[] = getPipelineOpenShiftNamespacesForOpenShiftCluster(owningTenant.name, project, projectProdRequest.deploymentPipeline, prodOpenshift);
 
-                    taskRunner.addTask(new CreateTeamDevOpsEnvironment({team: owningTeam}, prodOpenshift, devopsEnvironmentDetails),
+                    taskRunner.addTask(new CreateTeamDevOpsEnvironment(owningTeam, prodOpenshift, devopsEnvironmentDetails),
                     ).addTask(
                         new CreateOpenshiftEnvironments(request, environmentsForCreation, prodOpenshift, devopsEnvironmentDetails),
                     ).addTask(

--- a/src/gluon/events/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/events/team/DevOpsEnvironmentRequested.ts
@@ -99,6 +99,9 @@ export class DevOpsEnvironmentRequested extends BaseQMEvent implements HandleEve
     }
 
     private async sendDevOpsSuccessfullyProvisionedMessage(ctx: HandlerContext, team: QMTeam) {
+
+        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[team.openShiftCloud].openshiftNonProd);
+
         const jenkinsHost = await this.ocService.getJenkinsHost(getDevOpsEnvironmentDetails(team.name).openshiftProjectId);
 
         const destination = await addressSlackChannelsFromContext(ctx, team.slack.teamChannel);

--- a/src/gluon/events/team/TeamOpenShiftCloudMigrated.ts
+++ b/src/gluon/events/team/TeamOpenShiftCloudMigrated.ts
@@ -1,0 +1,165 @@
+import {
+    EventFired,
+    HandlerContext,
+    HandlerResult,
+    logger,
+} from "@atomist/automation-client";
+import {EventHandler} from "@atomist/automation-client/lib/decorators";
+import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
+import {timeout, TimeoutError} from "promise-timeout";
+import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
+import {QMConfig} from "../../../config/QMConfig";
+import {QMApplication} from "../../services/gluon/ApplicationService";
+import {GluonService} from "../../services/gluon/GluonService";
+import {OCService} from "../../services/openshift/OCService";
+import {ConfigurePackageInJenkins} from "../../tasks/packages/ConfigurePackageInJenkins";
+import {ConfigureJenkinsForProject} from "../../tasks/project/ConfigureJenkinsForProject";
+import {CreateOpenshiftEnvironments} from "../../tasks/project/CreateOpenshiftEnvironments";
+import {CreateOpenshiftResourcesInProject} from "../../tasks/project/CreateOpenshiftResourcesInProject";
+import {TaskListMessage} from "../../tasks/TaskListMessage";
+import {TaskRunner} from "../../tasks/TaskRunner";
+import {AddJenkinsToDevOpsEnvironment} from "../../tasks/team/AddJenkinsToDevOpsEnvironment";
+import {CreateTeamDevOpsEnvironment} from "../../tasks/team/CreateTeamDevOpsEnvironment";
+import {
+    getAllProjectOpenshiftNamespaces,
+    OpenshiftProjectEnvironmentRequest,
+    OpenShiftProjectNamespace,
+    QMProject,
+} from "../../util/project/Project";
+import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
+import {
+    ChannelMessageClient,
+    handleQMError,
+    QMMessageClient,
+} from "../../util/shared/Error";
+import {QMTenant} from "../../util/shared/Tenants";
+import {QMTeam} from "../../util/team/Teams";
+import {EventToGluon} from "../../util/transform/EventToGluon";
+
+@EventHandler("Receive TeamOpenShiftCloudMigratedEvent events", `
+subscription TeamOpenShiftCloudMigratedEvent {
+  TeamOpenShiftCloudMigratedEvent {
+    id
+    team {
+      teamId
+      name
+      slackIdentity {
+        teamChannel
+      }
+      openShiftCloud
+      owners {
+        firstName
+        domainUsername
+        slackIdentity {
+          screenName
+        }
+      }
+      members {
+        firstName
+        domainUsername
+        slackIdentity {
+          screenName
+        }
+      }
+    }
+    requestedBy {
+      firstName
+      slackIdentity {
+        screenName
+      }
+    }
+  }
+}
+`)
+export class TeamOpenShiftCloudMigrated extends BaseQMEvent implements HandleEvent<any> {
+
+    constructor(private ocService: OCService = new OCService(), private gluonService = new GluonService()) {
+        super();
+    }
+
+    public async handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info(`Ingested TeamOpenShiftCloudMigrated event: ${JSON.stringify(event.data)}`);
+
+        const devOpsRequestedEvent = event.data.TeamOpenShiftCloudMigratedEvent[0];
+
+        try {
+            const team: QMTeam = EventToGluon.gluonTeam(devOpsRequestedEvent.team);
+            const qmMessageClient = new ChannelMessageClient(ctx).addDestination(team.slack.teamChannel);
+
+            const taskRunner = await this.createMigrateTeamToCloudTasks(qmMessageClient, team);
+
+            await taskRunner.execute(ctx);
+
+            this.succeedEvent();
+
+            return qmMessageClient.send(`:rocket: Team successfully migrated to *${team.openShiftCloud}* cloud.`);
+
+        } catch (error) {
+            this.failEvent();
+            return await this.handleError(ctx, error, devOpsRequestedEvent.team.slackIdentity.teamChannel);
+        }
+    }
+
+    private async createMigrateTeamToCloudTasks(qmMessageClient: QMMessageClient, team: QMTeam) {
+        const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Migrating Team to cloud *${team.openShiftCloud}* started:`,
+            qmMessageClient);
+        const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
+
+        taskRunner.addTask(
+            new CreateTeamDevOpsEnvironment(team, QMConfig.subatomic.openshiftClouds[team.openShiftCloud].openshiftNonProd),
+        ).addTask(
+            new AddJenkinsToDevOpsEnvironment(team),
+        );
+
+        const projects = await this.gluonService.projects.gluonProjectsWhichBelongToGluonTeam(team.name, false);
+        for (const project of projects) {
+            await this.addCreateProjectEnvironmentsTasks(taskRunner, team, project);
+        }
+
+        return taskRunner;
+    }
+
+    private async addCreateProjectEnvironmentsTasks(taskRunner: TaskRunner, team: QMTeam, project: QMProject) {
+
+        const tenant: QMTenant = await this.gluonService.tenants.gluonTenantFromTenantId(project.owningTenant);
+
+        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[team.openShiftCloud].openshiftNonProd);
+
+        const environmentsForCreation: OpenShiftProjectNamespace[] = getAllProjectOpenshiftNamespaces(tenant, project);
+
+        const createOpenshiftEnvironmentsDetails: OpenshiftProjectEnvironmentRequest = {
+            project,
+            owningTenant: tenant,
+            teams: [team],
+        };
+
+        const openShiftNonProd: OpenShiftConfig = QMConfig.subatomic.openshiftClouds[team.openShiftCloud].openshiftNonProd;
+
+        taskRunner.addTask(
+            new CreateOpenshiftEnvironments(createOpenshiftEnvironmentsDetails, environmentsForCreation, openShiftNonProd),
+        ).addTask(
+            new ConfigureJenkinsForProject(createOpenshiftEnvironmentsDetails, project.devDeploymentPipeline, project.releaseDeploymentPipelines, openShiftNonProd),
+        );
+
+        const resourceKindsForExport = ["Service", "DeploymentConfig", "ImageStream", "Route", "PersistentVolumeClaim", "Secret", "ConfigMap"];
+
+        for (const environment of environmentsForCreation) {
+            const allResources = await this.ocService.exportAllResources(environment.namespace, resourceKindsForExport);
+            taskRunner.addTask(
+                new CreateOpenshiftResourcesInProject([environment], environment.namespace, allResources, openShiftNonProd),
+                undefined,
+                0,
+            );
+        }
+
+        const applications: QMApplication[] = await this.gluonService.applications.gluonApplicationsLinkedToGluonProject(project.name, false);
+
+        for (const application of applications) {
+            taskRunner.addTask(new ConfigurePackageInJenkins(application, project), `*Create ${application.name} application Jenkins job*`);
+        }
+    }
+
+    private async handleError(ctx: HandlerContext, error, teamChannel: string) {
+        return await handleQMError(new ChannelMessageClient(ctx).addDestination(teamChannel), error);
+    }
+}

--- a/src/gluon/services/gluon/ApplicationService.ts
+++ b/src/gluon/services/gluon/ApplicationService.ts
@@ -15,7 +15,7 @@ export class ApplicationService {
     constructor(public axiosInstance = new AwaitAxios()) {
     }
 
-    public async gluonApplicationsLinkedToGluonProject(gluonProjectName: string, requestActionOnFailure: boolean = true): Promise<any> {
+    public async gluonApplicationsLinkedToGluonProject(gluonProjectName: string, requestActionOnFailure: boolean = true): Promise<any | QMApplication[]> {
         logger.debug(`Trying to get gluon applications associated to projectName. gluonProjectName: ${gluonProjectName} `);
 
         const result = await this.axiosInstance.get(`${QMConfig.subatomic.gluon.baseUrl}/applications?projectName=${gluonProjectName}`);

--- a/src/gluon/services/gluon/TeamService.ts
+++ b/src/gluon/services/gluon/TeamService.ts
@@ -155,4 +155,24 @@ export class TeamService {
         }
         return result.data._embedded.teamResources;
     }
+
+    public async updateTeamOpenShiftCloud(teamId: string, openShiftCloud: string, requestedByMemberId: string, rawResult = false): Promise<any> {
+        logger.debug(`Trying to update gluon team openShiftCloud. teamId: ${teamId}, openShiftCloud: ${openShiftCloud}, requestedByMemberId: ${requestedByMemberId} `);
+
+        const teamUpdate = {
+            createdBy: requestedByMemberId,
+            openShiftCloud,
+        };
+
+        const teamUpdateResult = await this.axiosInstance.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`, teamUpdate);
+
+        if (rawResult) {
+            return teamUpdateResult;
+        } else if (!isSuccessCode(teamUpdateResult.status)) {
+            logger.error(`Failed to update team ${teamId}. Error: ${inspect(teamUpdateResult)}`);
+            throw new QMError(`Unable to update team with id ${teamId}. Please make sure that you are an owner of the team.`);
+        }
+
+        return teamUpdateResult.data;
+    }
 }

--- a/src/gluon/services/openshift/OCImageService.ts
+++ b/src/gluon/services/openshift/OCImageService.ts
@@ -10,7 +10,7 @@ export class OCImageService {
 
     get openShiftApi(): OpenShiftApi {
         if (this.openShiftApiInstance === undefined) {
-            logger.error(`Failed to access the openShiftApiInstance. Make sure the you have performed an OCService.login command`);
+            logger.error(`Failed to access the openShiftApiInstance. Make sure the you have performed an OCService.setOpenShiftDetails command`);
             throw new QMError("OpenShift login failure!");
         }
         return this.openShiftApiInstance;

--- a/src/gluon/services/openshift/OCService.ts
+++ b/src/gluon/services/openshift/OCService.ts
@@ -25,7 +25,7 @@ export class OCService {
 
     get openShiftApi(): OpenShiftApi {
         if (this.openShiftApiInstance === undefined) {
-            logger.error(`Failed to access the openShiftApiInstance. Make sure the you have performed an OCService.login command`);
+            logger.error(`Failed to access the openShiftApiInstance. Make sure the you have performed an OCService.setOpenShiftDetails command`);
             throw new QMError("OpenShift login failure!");
         }
         return this.openShiftApiInstance;

--- a/src/gluon/services/openshift/OCService.ts
+++ b/src/gluon/services/openshift/OCService.ts
@@ -499,10 +499,9 @@ export class OCService {
         logger.debug("Extracting raw ssh key from cicd key");
         // Ignore the ssh-rsa encoding string, and any user name details at the end.
         const nme = "subatomic-config-server";
-        const rawSSHKey = QMConfig.subatomic.bitbucket.cicdKey.split(" ")[1];
+        const rawSSHKey = Buffer.from(QMConfig.subatomic.bitbucket.cicdKey.split(" ")[1]).toString("base64");
         const cicdPrivateKey = fs.readFileSync(
-            QMConfig.subatomic.bitbucket.cicdPrivateKeyPath,
-            "utf8").split("-----")[2].replace(/[\n\r]/g, "");
+            QMConfig.subatomic.bitbucket.cicdPrivateKeyPath).toString("base64");
 
         const secretResource: OpenshiftResource = {
             kind: "Secret",

--- a/src/gluon/services/openshift/OCService.ts
+++ b/src/gluon/services/openshift/OCService.ts
@@ -619,10 +619,12 @@ export class OCService {
         return project;
     }
 
-    public async exportAllResources(projectIdNameSpace: string): Promise<OpenshiftListResource> {
+    public async exportAllResources(
+        projectIdNameSpace: string,
+        resourceKindsRequired: string[] = ["Service", "DeploymentConfig", "ImageStream", "Route", "PersistentVolumeClaim"],
+    ): Promise<OpenshiftListResource> {
         logger.debug("Trying to export all required resources...");
 
-        const resourceKindsRequired: string[] = ["Service", "DeploymentConfig", "ImageStream", "Route", "PersistentVolumeClaim"];
         const resources: OpenshiftResource[] = [];
 
         for (const resourceKind of resourceKindsRequired) {

--- a/src/gluon/services/projects/GenericOpenshiftResourceService.ts
+++ b/src/gluon/services/projects/GenericOpenshiftResourceService.ts
@@ -10,6 +10,7 @@ export class GenericOpenshiftResourceService {
         this.cleanImageStreams(resources);
         this.cleanRoutes(resources);
         this.cleanPVCs(resources);
+        this.cleanSecrets(resources);
 
         return resources;
     }
@@ -90,6 +91,17 @@ export class GenericOpenshiftResourceService {
             if (resource.kind === "Route") {
                 delete resource.spec.host;
                 resource.status = {};
+            }
+        }
+    }
+
+    private cleanSecrets(allResources: OpenshiftResource[]) {
+        for (let i = allResources.length - 1; i >= 0; i--) {
+            const resource = allResources[i];
+            if (resource.kind === "Secret") {
+                if (resource.metadata.name.indexOf("kubernetes.io/") !== -1) {
+                    allResources = allResources.splice(i, 1);
+                }
             }
         }
     }

--- a/src/gluon/tasks/Task.ts
+++ b/src/gluon/tasks/Task.ts
@@ -18,7 +18,7 @@ export abstract class Task {
         const startTask = this.taskListMessage.countTasks();
         this.configureTaskListMessage(taskListMessage);
         const lastTask = this.taskListMessage.countTasks();
-        for (let i = startTask; i < lastTask - 1; i++) {
+        for (let i = startTask; i <= lastTask - 1; i++) {
             this.taskListMessage.indentTaskAtIndex(i, indentation);
         }
     }

--- a/src/gluon/tasks/Task.ts
+++ b/src/gluon/tasks/Task.ts
@@ -13,9 +13,14 @@ export abstract class Task {
         return await this.executeTask(ctx);
     }
 
-    public setTaskListMessage(taskListMessage: TaskListMessage) {
+    public setTaskListMessage(taskListMessage: TaskListMessage, indentation: number) {
         this.taskListMessage = taskListMessage;
+        const startTask = this.taskListMessage.countTasks();
         this.configureTaskListMessage(taskListMessage);
+        const lastTask = this.taskListMessage.countTasks();
+        for (let i = startTask; i < lastTask - 1; i++) {
+            this.taskListMessage.indentTaskAtIndex(i, indentation);
+        }
     }
 
     protected abstract async executeTask(ctx: HandlerContext): Promise<boolean>;

--- a/src/gluon/tasks/TaskListMessage.ts
+++ b/src/gluon/tasks/TaskListMessage.ts
@@ -20,15 +20,15 @@ export class TaskListMessage {
         this.tasks = {};
         this.taskOrder = [];
         this.statusCosmetics.set(TaskStatus.Pending, {
-            color:  QMColours.stdMuddyYellow.hex,
+            color: QMColours.stdMuddyYellow.hex,
             symbol: "●",
         });
         this.statusCosmetics.set(TaskStatus.Failed, {
-            color:  QMColours.stdReddyMcRedFace.hex,
+            color: QMColours.stdReddyMcRedFace.hex,
             symbol: "✗",
         });
         this.statusCosmetics.set(TaskStatus.Successful, {
-            color:  QMColours.stdGreenyMcAppleStroodle.hex,
+            color: QMColours.stdGreenyMcAppleStroodle.hex,
             symbol: "✓",
         });
     }
@@ -36,6 +36,21 @@ export class TaskListMessage {
     public addTask(key: string, description: string) {
         this.tasks[key] = {description, status: TaskStatus.Pending};
         this.taskOrder.push(key);
+    }
+
+    public countTasks(): number {
+        return this.taskOrder.length;
+    }
+
+    public indentTaskAtIndex(taskIndex: number, indentation: number) {
+        const task: Task = this.tasks[this.taskOrder[taskIndex]];
+        const lines = task.description.split("\n");
+        let newDescription = "";
+        for (const line of lines) {
+            const indentationString = "\t".repeat(indentation);
+            newDescription += `${indentationString}${line}\n`;
+        }
+        task.description = newDescription;
     }
 
     public async succeedTask(key: string) {

--- a/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
+++ b/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
@@ -8,6 +8,7 @@ import {OCService} from "../../services/openshift/OCService";
 import {getJenkinsBitbucketAccessCredential} from "../../util/jenkins/JenkinsCredentials";
 import {
     getAllPipelineOpenshiftNamespaces,
+    OpenshiftProjectEnvironmentRequest,
     OpenShiftProjectNamespace,
     QMDeploymentPipeline,
 } from "../../util/project/Project";
@@ -23,9 +24,9 @@ export class ConfigureJenkinsForProject extends Task {
     private readonly TASK_CREATE_JENKINS_BUILD_TEMPLATE = TaskListMessage.createUniqueTaskName("JenkinsBuildTemplate");
     private readonly TASK_ADD_JENKINS_CREDENTIALS = TaskListMessage.createUniqueTaskName("JenkinsCredentials");
 
-    private allEnvironmentsForCreation: OpenShiftProjectNamespace[];
+    private readonly allEnvironmentsForCreation: OpenShiftProjectNamespace[];
 
-    constructor(private environmentsRequestedEvent,
+    constructor(private environmentsRequestedEvent: OpenshiftProjectEnvironmentRequest,
                 private devDeployPipelineForCreation: QMDeploymentPipeline,
                 private releaseDeploymentPipelinesForCreation: QMDeploymentPipeline[],
                 private openshiftEnvironment: OpenShiftConfig,
@@ -39,7 +40,7 @@ export class ConfigureJenkinsForProject extends Task {
     }
 
     protected configureTaskListMessage(taskListMessage: TaskListMessage) {
-        this.taskListMessage.addTask(this.TASK_HEADER, `*Configure project in Jenkins on ${this.openshiftEnvironment.name}*`);
+        this.taskListMessage.addTask(this.TASK_HEADER, `*Configure ${this.environmentsRequestedEvent.project.name} project in Jenkins on ${this.openshiftEnvironment.name}*`);
         this.taskListMessage.addTask(this.TASK_ADD_JENKINS_SA_RIGHTS, "\tGrant Jenkins Service Account permissions");
         this.taskListMessage.addTask(this.TASK_CREATE_JENKINS_BUILD_TEMPLATE, "\tCreate Jenkins build folder");
         this.taskListMessage.addTask(this.TASK_ADD_JENKINS_CREDENTIALS, "\tAdd project environment credentials to Jenkins");

--- a/src/gluon/tasks/project/CreateOpenshiftEnvironments.ts
+++ b/src/gluon/tasks/project/CreateOpenshiftEnvironments.ts
@@ -30,7 +30,7 @@ export class CreateOpenshiftEnvironments extends Task {
     }
 
     protected configureTaskListMessage(taskListMessage: TaskListMessage) {
-        this.taskListMessage.addTask(this.TASK_HEADER, `*Create project environments on ${this.openshiftEnvironment.name}*`);
+        this.taskListMessage.addTask(this.TASK_HEADER, `*Create ${this.environmentsRequestedEvent.project.name} project environments on ${this.openshiftEnvironment.name}*`);
         for (const environment of this.environmentsForCreation) {
             const internalTaskId = `${environment.namespace}Environment`;
             this.dynamicTaskNameStore[internalTaskId] = TaskListMessage.createUniqueTaskName(internalTaskId);

--- a/src/gluon/tasks/project/CreateOpenshiftResourcesInProject.ts
+++ b/src/gluon/tasks/project/CreateOpenshiftResourcesInProject.ts
@@ -27,7 +27,7 @@ export class CreateOpenshiftResourcesInProject extends Task {
             const internalTaskId = `${environment.postfix}Environment`;
             const projectName = environment.namespace;
             this.dynamicTaskNameStore[internalTaskId] = TaskListMessage.createUniqueTaskName(internalTaskId);
-            this.taskListMessage.addTask(this.dynamicTaskNameStore[internalTaskId], `\tCreate resources in *${this.openshiftEnvironment.name} - ${projectName}*`);
+            this.taskListMessage.addTask(this.dynamicTaskNameStore[internalTaskId], `Create resources in *${this.openshiftEnvironment.name} - ${projectName}*`);
         }
     }
 

--- a/src/gluon/tasks/team/CreateTeamDevOpsEnvironment.ts
+++ b/src/gluon/tasks/team/CreateTeamDevOpsEnvironment.ts
@@ -19,9 +19,9 @@ export class CreateTeamDevOpsEnvironment extends Task {
     private readonly TASK_OPENSHIFT_RESOURCES = TaskListMessage.createUniqueTaskName("Resources");
     private readonly TASK_SECRETS = TaskListMessage.createUniqueTaskName("ConfigSecrets");
 
-    constructor(private devOpsRequestedEvent: { team: QMTeam },
+    constructor(private team: QMTeam,
                 private openshiftEnvironment: OpenShiftConfig,
-                private devopsEnvironmentDetails: DevOpsEnvironmentDetails = getDevOpsEnvironmentDetails(devOpsRequestedEvent.team.name),
+                private devopsEnvironmentDetails: DevOpsEnvironmentDetails = getDevOpsEnvironmentDetails(team.name),
                 private ocService = new OCService()) {
         super();
     }
@@ -40,12 +40,12 @@ export class CreateTeamDevOpsEnvironment extends Task {
 
         await this.ocService.setOpenShiftDetails(this.openshiftEnvironment);
 
-        await this.createDevOpsEnvironment(projectId, this.devOpsRequestedEvent.team.name);
+        await this.createDevOpsEnvironment(projectId, this.team.name);
 
         await this.taskListMessage.succeedTask(this.TASK_OPENSHIFT_ENV);
 
         await this.ocService.addTeamMembershipPermissionsToProject(projectId,
-            this.devOpsRequestedEvent.team);
+            this.team);
 
         await this.taskListMessage.succeedTask(this.TASK_OPENSHIFT_PERMISSIONS);
 

--- a/src/gluon/util/recursiveparam/GluonParameterSetters.ts
+++ b/src/gluon/util/recursiveparam/GluonParameterSetters.ts
@@ -87,23 +87,30 @@ export async function setGluonTeamOpenShiftCloud(
         commandHandler.openShiftCloud = team.openShiftCloud;
         return {setterSuccess: true};
     } else {
-        return {
-            setterSuccess: false,
-            messagePrompt: createMenuAttachment(
-                Object.keys(QMConfig.subatomic.openshiftClouds).map(cloudName => {
-                    return {
-                        value: cloudName,
-                        text: cloudName,
-                    };
-                }),
-                commandHandler,
-                selectionMessage,
-                selectionMessage,
-                "Select OpenShift Cloud",
-                "openShiftCloud",
-            ),
-        };
+        return await setGluonTeamOpenShiftCloudForced(ctx, commandHandler, selectionMessage);
     }
+}
+
+export async function setGluonTeamOpenShiftCloudForced(
+    ctx: HandlerContext,
+    commandHandler: GluonTeamOpenShiftCloudBaseSetter,
+    selectionMessage: string = "Please select an OpenShift cloud"): Promise<RecursiveSetterResult> {
+    return {
+        setterSuccess: false,
+        messagePrompt: createMenuAttachment(
+            Object.keys(QMConfig.subatomic.openshiftClouds).map(cloudName => {
+                return {
+                    value: cloudName,
+                    text: cloudName,
+                };
+            }),
+            commandHandler,
+            selectionMessage,
+            selectionMessage,
+            "Select OpenShift Cloud",
+            "openShiftCloud",
+        ),
+    };
 }
 
 export function GluonTeamOpenShiftCloudParam(details: RecursiveParameterDetails) {
@@ -111,11 +118,14 @@ export function GluonTeamOpenShiftCloudParam(details: RecursiveParameterDetails)
     return RecursiveParameter(details);
 }
 
-export interface GluonTeamOpenShiftCloudSetter {
-    gluonService: GluonService;
-    teamName: string;
+export interface GluonTeamOpenShiftCloudBaseSetter {
     openShiftCloud: string;
     handle: (ctx: HandlerContext) => Promise<HandlerResult>;
+}
+
+export interface GluonTeamOpenShiftCloudSetter extends GluonTeamOpenShiftCloudBaseSetter {
+    gluonService: GluonService;
+    teamName: string;
 }
 
 export async function setGluonProjectName(

--- a/src/graphql/ingester/TeamOpenShiftCloudMigratedEvent.graphql
+++ b/src/graphql/ingester/TeamOpenShiftCloudMigratedEvent.graphql
@@ -1,0 +1,4 @@
+type TeamOpenShiftCloudMigratedEvent @rootType {
+    team: GluonTeam
+    requestedBy: ActionedBy
+}

--- a/src/graphql/ingester/TeamOpenShiftCloudMigratedEvent.graphql
+++ b/src/graphql/ingester/TeamOpenShiftCloudMigratedEvent.graphql
@@ -1,4 +1,5 @@
 type TeamOpenShiftCloudMigratedEvent @rootType {
     team: GluonTeam
     requestedBy: ActionedBy
+    previousCloud: String
 }


### PR DESCRIPTION
Provides a command `sub team migrate cloud` which will do the following:

- Recreate the Team DevOps environment on the new cloud
- Recreate all project environments on the new cloud
- Find all the `Service`, `DeploymentConfig`, `ImageStream`, `Route`, `PersistentVolumeClaim`, `Secret`, `ConfigMap` resources in all the project environments and move them to the equivalent environments in the new cloud.
- Recreates all jenkins jobs in the new clouds DevOps Jenkins instance.

Closes #615 