### PR TITLE
Add DC package definition environment variables

### DIFF
--- a/resources/package-definitions/deployable/maven-springboot-1.json
+++ b/resources/package-definitions/deployable/maven-springboot-1.json
@@ -4,5 +4,12 @@
     "imageStream": "jdk8-maven3-newrelic-subatomic:2.0",
     "envVariables": {}
   },
+  "deploymentConfig": {
+    "envVariables": {
+      "SPRING_CLOUD_CONFIG_LABEL": "{{openShiftNamespaceDetails.postfix}}",
+      "SPRING_APPLICATION_NAME": "{{applicationName}}",
+      "SPRING_PROFILES_ACTIVE": "{{openShiftNamespaceDetails.postfix}},logging"
+    }
+  },
   "jenkinsfile": "maven-spring-boot"
 }

--- a/resources/package-definitions/deployable/maven-springboot-2.json
+++ b/resources/package-definitions/deployable/maven-springboot-2.json
@@ -4,5 +4,12 @@
     "imageStream": "jdk8-maven3-newrelic-subatomic:2.0",
     "envVariables": {}
   },
+  "deploymentConfig": {
+    "envVariables": {
+      "SPRING_CLOUD_CONFIG_LABEL": "{{openShiftNamespaceDetails.postfix}}",
+      "SPRING_APPLICATION_NAME": "{{applicationName}}",
+      "SPRING_PROFILES_ACTIVE": "{{openShiftNamespaceDetails.postfix}},logging"
+    }
+  },
   "jenkinsfile": "maven-spring-boot"
 }

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -93,6 +93,8 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
 
     public buildEnvironmentVariables: { [key: string]: string } = {};
 
+    public deploymentEnvironmentVariables: { [key: string]: string } = {};
+
     constructor(public gluonService = new GluonService(),
                 public ocService = new OCService()) {
         super();
@@ -131,6 +133,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
                         buildEnvironmentVariables: this.buildEnvironmentVariables,
                         openshiftTemplate: this.openshiftTemplate,
                         baseS2IImage: this.imageName,
+                        deploymentEnvironmentVariables: this.deploymentEnvironmentVariables,
                     },
                     {
                         teamName: this.teamName,

--- a/src/gluon/services/openshift/OCService.ts
+++ b/src/gluon/services/openshift/OCService.ts
@@ -338,7 +338,7 @@ export class OCService {
             const returnedTemplate: OpenshiftResource = response.data;
 
             // Build the list object from the response object (objects[] maps to items[])
-            const openShiftResourceList: OpenshiftResource = {
+            const openShiftResourceList: OpenshiftListResource = {
                 kind: "List",
                 apiVersion: "v1",
                 metadata: {},

--- a/src/gluon/tasks/packages/ConfigurePackageInJenkins.ts
+++ b/src/gluon/tasks/packages/ConfigurePackageInJenkins.ts
@@ -10,7 +10,7 @@ import {GitProject} from "@atomist/automation-client/lib/project/git/GitProject"
 import _ = require("lodash");
 import {QMConfig} from "../../../config/QMConfig";
 import {isSuccessCode} from "../../../http/Http";
-import {QMTemplate} from "../../../template/QMTemplate";
+import {QMFileTemplate} from "../../../template/QMTemplate";
 import {QMApplication} from "../../services/gluon/ApplicationService";
 import {GluonService} from "../../services/gluon/GluonService";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
@@ -90,7 +90,7 @@ export class ConfigurePackageInJenkins extends Task {
         const jenkinsHost: string = await this.ocService.getJenkinsHost(teamDevOpsProjectId);
         logger.debug(`Using Jenkins Route host [${jenkinsHost}] to add Bitbucket credentials`);
 
-        const jenkinsTemplate: QMTemplate = new QMTemplate(`resources/templates/jenkins/${jenkinsJobTemplate.templateFilename}`);
+        const jenkinsTemplate: QMFileTemplate = new QMFileTemplate(`resources/templates/jenkins/${jenkinsJobTemplate.templateFilename}`);
         const builtTemplate: string = jenkinsTemplate.build(
             {
                 gluonApplicationName: application.name,
@@ -138,7 +138,7 @@ export class ConfigurePackageInJenkins extends Task {
                 await project.findFile(destinationJenkinsfileName);
             } catch (error) {
                 logger.info("Jenkinsfile doesnt exist. Adding it!");
-                const jenkinsTemplate: QMTemplate = new QMTemplate(this.getPathFromJenkinsfileName(jenkinsfileName as string));
+                const jenkinsTemplate: QMFileTemplate = new QMFileTemplate(this.getPathFromJenkinsfileName(jenkinsfileName as string));
                 await project.addFile(destinationJenkinsfileName,
                     jenkinsTemplate.build({
                         devDeploymentEnvironments: this.project.devDeploymentPipeline.environments,

--- a/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
+++ b/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
@@ -2,7 +2,7 @@ import {HandlerContext, logger} from "@atomist/automation-client";
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
 import {isSuccessCode} from "../../../http/Http";
-import {QMTemplate} from "../../../template/QMTemplate";
+import {QMFileTemplate} from "../../../template/QMTemplate";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
 import {OCService} from "../../services/openshift/OCService";
 import {getJenkinsBitbucketAccessCredential} from "../../util/jenkins/JenkinsCredentials";
@@ -86,7 +86,7 @@ export class ConfigureJenkinsForProject extends Task {
     }
 
     private async createJenkinsBuildTemplate(environmentsRequestedEvent, teamDevOpsProjectId: string, jenkinsHost: string, token: string) {
-        const projectTemplate: QMTemplate = new QMTemplate("resources/templates/jenkins/jenkins-openshift-environment-credentials.xml");
+        const projectTemplate: QMFileTemplate = new QMFileTemplate("resources/templates/jenkins/jenkins-openshift-environment-credentials.xml");
 
         const parameters: { [k: string]: any } = {
             projectName: environmentsRequestedEvent.project.name,

--- a/src/gluon/tasks/team/AddJenkinsToDevOpsEnvironment.ts
+++ b/src/gluon/tasks/team/AddJenkinsToDevOpsEnvironment.ts
@@ -92,11 +92,11 @@ export class AddJenkinsToDevOpsEnvironment extends Task {
     }
 
     private async createJenkinsDeploymentConfig(projectId: string, openShiftCloud: string) {
-        logger.info("Processing Jenkins QMTemplate...");
+        logger.info("Processing Jenkins QMFileTemplate...");
         const openShiftResourceList = await this.ocService.processJenkinsTemplateForDevOpsProject(projectId, openShiftCloud);
         try {
             await this.ocService.getDeploymentConfigInNamespace("jenkins", projectId);
-            logger.warn("Jenkins QMTemplate has already been processed, deployment exists");
+            logger.warn("Jenkins QMFileTemplate has already been processed, deployment exists");
         } catch (error) {
             await this.ocService.applyResourceFromDataInNamespace(openShiftResourceList, projectId);
         }

--- a/src/gluon/util/packages/packagedef/PackageDefinition.ts
+++ b/src/gluon/util/packages/packagedef/PackageDefinition.ts
@@ -1,6 +1,7 @@
 export interface PackageDefinition {
     openshiftTemplate?: string;
     buildConfig: BuildConfig;
+    deploymentConfig?: DeploymentConfig;
     jenkinsfile?: string;
     requiredEnvironmentVariables?: RequiredEnvironmentVariable[];
 }
@@ -8,6 +9,10 @@ export interface PackageDefinition {
 export interface BuildConfig {
     imageStream: string;
     envVariables?: { [key: string]: string };
+}
+
+export interface DeploymentConfig {
+    envVariables: { [key: string]: string };
 }
 
 export interface RequiredEnvironmentVariable {

--- a/src/gluon/util/project/Project.ts
+++ b/src/gluon/util/project/Project.ts
@@ -81,11 +81,15 @@ export function getPipelineOpenShiftNamespacesForOpenShiftCluster(tenantName: st
     const environmentsForCreation: OpenShiftProjectNamespace[] = [];
 
     for (const environment of openShiftCluster.defaultEnvironments) {
+        let postFix = `${_.kebabCase(deploymentPipeline.tag)}-${environment.id}`;
+        if (_.isEmpty(deploymentPipeline.tag)) {
+            postFix = environment.id;
+        }
         environmentsForCreation.push(
             {
                 namespace: getProjectOpenshiftNamespace(tenantName, project.name, deploymentPipeline.tag, environment.id),
                 displayName: getProjectDisplayName(tenantName, project.name, deploymentPipeline.tag, environment.description),
-                postfix: environment.id,
+                postfix: postFix,
             },
         );
     }
@@ -106,9 +110,21 @@ export function getAllProjectOpenshiftNamespaces(owningTenant: QMTenant, project
     return environmentsForCreation;
 }
 
+export function getAllPipelineOpenshiftNamespacesForAllPipelines(tenantName: string, project: QMProject) {
+    const namespaces: OpenShiftProjectNamespace[] = getAllPipelineOpenshiftNamespaces(tenantName, project.name, project.devDeploymentPipeline);
+    for (const pipeline of project.releaseDeploymentPipelines) {
+        namespaces.push(...getAllPipelineOpenshiftNamespaces(tenantName, project.name, pipeline));
+    }
+    return namespaces;
+}
+
 export function getAllPipelineOpenshiftNamespaces(owningTenantName: string, projectName: string, pipeline: QMDeploymentPipeline): OpenShiftProjectNamespace[] {
     const environmentsForCreation: OpenShiftProjectNamespace[] = [];
     for (const environment of pipeline.environments) {
+        let postFix = `${_.kebabCase(pipeline.tag)}-${environment.postfix}`;
+        if (_.isEmpty(pipeline.tag)) {
+            postFix = environment.postfix;
+        }
         environmentsForCreation.push(
             {
                 namespace: getProjectOpenshiftNamespace(owningTenantName, projectName, pipeline.tag, environment.postfix),

--- a/src/gluon/util/resources/JsonLoader.ts
+++ b/src/gluon/util/resources/JsonLoader.ts
@@ -1,14 +1,14 @@
-import {QMTemplate} from "../../../template/QMTemplate";
+import {QMFileTemplate} from "../../../template/QMTemplate";
 
 export class JsonLoader {
-    protected readFileContents(filePath: string): any {
+    public readFileContents(filePath: string): any {
         const fs = require("fs");
         const buffer = fs.readFileSync(filePath);
         return JSON.parse(buffer.toString());
     }
 
-    protected readTemplatizedFileContents(filePath: string, parameters: { [k: string]: any }): any {
-        const template = new QMTemplate(filePath);
+    public readTemplatizedFileContents(filePath: string, parameters: { [k: string]: any }): any {
+        const template = new QMFileTemplate(filePath);
         return JSON.parse(template.build(parameters));
     }
 }

--- a/src/template/QMTemplate.ts
+++ b/src/template/QMTemplate.ts
@@ -5,16 +5,14 @@ export class QMTemplate {
 
     private readonly template: HandlebarsTemplateDelegate;
 
-    constructor(templateFile: string) {
-        const fs = require("fs");
-        const buffer = fs.readFileSync(templateFile);
+    constructor(rawTemplateString: string) {
         Handlebars.registerHelper("toLowerCase", str => str.toLowerCase());
         Handlebars.registerHelper("toUpperCase", str => str.toUpperCase());
         Handlebars.registerHelper("toKebabCase", str => _.kebabCase(str));
         Handlebars.registerHelper("toCamelCase", str => _.camelCase(str));
         Handlebars.registerHelper("toPascalCase", str => _.capitalize(_.camelCase(str)));
         Handlebars.registerHelper("toUpperSnakeCase", str => _.snakeCase(str).toUpperCase());
-        this.template = Handlebars.compile(buffer.toString());
+        this.template = Handlebars.compile(rawTemplateString);
     }
 
     public build(parameters: { [k: string]: any }): string {
@@ -23,7 +21,7 @@ export class QMTemplate {
         return this.template(safeParameters);
     }
 
-    public toSafeStrings(obj: any) {
+    private toSafeStrings(obj: any) {
         for (const property in obj) {
             if (obj.hasOwnProperty(property)) {
                 if (typeof obj[property] === "object") {
@@ -33,5 +31,14 @@ export class QMTemplate {
                 }
             }
         }
+    }
+}
+
+export class QMFileTemplate extends QMTemplate {
+
+    constructor(templateFile: string) {
+        const fs = require("fs");
+        const buffer = fs.readFileSync(templateFile);
+        super(buffer.toString());
     }
 }


### PR DESCRIPTION
This adds functionality that allows configuring default environment variables in deployment configs. This is useful for settings things like spring cloud config environment variables automatically. An example of this can be seen in the `maven-springboot-1` and `maven-springboot-2` package definitions.