### PR TITLE
Jenkins Token Credential Creation Fix 

### DIFF
--- a/src/gluon/tasks/team/AddJenkinsToProdEnvironment.ts
+++ b/src/gluon/tasks/team/AddJenkinsToProdEnvironment.ts
@@ -1,5 +1,6 @@
 import {HandlerContext, logger} from "@atomist/automation-client";
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
+import {QMConfig} from "../../../config/QMConfig";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
 import {OCService} from "../../services/openshift/OCService";
 import {
@@ -53,7 +54,8 @@ export class AddJenkinsToProdEnvironment extends Task {
         }
         await this.taskListMessage.succeedTask(this.TASK_ADD_JENKINS_SA_RIGHTS);
 
-        await this.ocService.setOpenShiftDetails(this.openshiftEnvironment);
+        // Add the prod token to the non prod jenkins instance
+        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[this.devOpsRequestedEvent.team.openShiftCloud].openshiftNonProd);
 
         const jenkinsToken = await this.ocService.getServiceAccountToken("subatomic-jenkins", teamDevOpsNonProd);
 


### PR DESCRIPTION
Corrected issue where we were logging into the wrong openshift to perform the token creation in jenkins.