### PR TITLE
Add member to subatomic community at onboarding #644 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,12 @@ Here is an example `local.json`:
         "enabled": false
       }
     }
-  }
+  },
+  "cluster": {
+    "enabled": false,
+    "workers": 1
+  },
+  "secondarySlackChannels": ["my-slack-channel","yet-another-slack-channel"]
 }
 ```
 

--- a/src/config/QMConfig.ts
+++ b/src/config/QMConfig.ts
@@ -22,6 +22,8 @@ export class QMConfig {
 
     public static proMetrics: ProMetrics;
 
+    public static secondarySlackChannels: string[];
+
     public static publicConfig() {
         return new PublicQMConfig();
     }
@@ -33,6 +35,7 @@ export class QMConfig {
         QMConfig.teamId = config.teamId;
         QMConfig.apiKey = config.apiKey;
         QMConfig.http = config.http;
+        QMConfig.secondarySlackChannels = config.secondarySlackChannels;
         QMConfig.proMetrics = config.proMetrics || {
             enabled: true,
         };

--- a/src/gluon/commands/member/OnboardMember.ts
+++ b/src/gluon/commands/member/OnboardMember.ts
@@ -15,6 +15,7 @@ import {QMConfig} from "../../../config/QMConfig";
 import {isSuccessCode} from "../../../http/Http";
 import {OnboardMemberMessages} from "../../messages/member/OnboardMemberMessages";
 import {GluonService} from "../../services/gluon/GluonService";
+import {OnboardMemberService} from "../../services/member/OnboardMemberService";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
 import {
     handleQMError,
@@ -53,13 +54,15 @@ export class OnboardMember extends BaseQMComand {
 
     public onboardMessages: OnboardMemberMessages = new OnboardMemberMessages();
 
-    constructor(private gluonService = new GluonService()) {
+    constructor(private gluonService = new GluonService(),
+                private onboardMemberService = new OnboardMemberService()) {
         super();
     }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             logger.info("Requesting new Gluon user");
+
             await this.createGluonTeamMember(
                 {
                     firstName: this.firstName,
@@ -71,15 +74,35 @@ export class OnboardMember extends BaseQMComand {
                         userId: this.userId,
                     },
                 });
-            const message = this.onboardMessages.presentTeamCreationAndApplicationOptions(this.firstName);
+
+            const secondaryChannelsInvited = await this.inviteMembersToSecondarySlackChannels(ctx);
+
+            const message = this.onboardMessages.presentTeamCreationAndApplicationOptions(this.firstName, secondaryChannelsInvited);
             const destination = await addressSlackUsersFromContext(ctx, this.userId);
             const result = await ctx.messageClient.send(message, destination);
+
             this.succeedCommand();
             return result;
         } catch (error) {
             this.failCommand();
             return await this.handleError(ctx, error);
         }
+    }
+
+    private async inviteMembersToSecondarySlackChannels(ctx: HandlerContext): Promise<string[]> {
+
+        const secondaryChannelsInvited: string[] = [];
+
+        for (const channel of QMConfig.secondarySlackChannels) {
+            try {
+                secondaryChannelsInvited.push(await this.onboardMemberService.inviteUserToSecondarySlackChannel(
+                    ctx, this.firstName, channel, this.userId, this.screenName));
+            } catch (error) {
+                await this.handleError(ctx, error);
+            }
+        }
+
+        return secondaryChannelsInvited;
     }
 
     private async createGluonTeamMember(teamMemberDetails: any) {

--- a/src/gluon/commands/member/OnboardMember.ts
+++ b/src/gluon/commands/member/OnboardMember.ts
@@ -11,6 +11,7 @@ import {
     Tags,
 } from "@atomist/automation-client/lib/decorators";
 import {addressSlackUsersFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {continueStatement} from "babel-types";
 import {QMConfig} from "../../../config/QMConfig";
 import {isSuccessCode} from "../../../http/Http";
 import {OnboardMemberMessages} from "../../messages/member/OnboardMemberMessages";

--- a/src/gluon/messages/member/OnboardMemberMessages.ts
+++ b/src/gluon/messages/member/OnboardMemberMessages.ts
@@ -5,11 +5,12 @@ import {CreateTeam} from "../../commands/team/CreateTeam";
 import {JoinTeam} from "../../commands/team/JoinTeam";
 
 export class OnboardMemberMessages {
-    public presentTeamCreationAndApplicationOptions(firstName: string): SlackMessage {
-        const text: string = `
-Welcome to the Subatomic environment *${firstName}*!
-Next steps are to either join an existing team or create a new one.
-                `;
+
+    public presentTeamCreationAndApplicationOptions(firstName: string, secondarySlackChannels: string[]): SlackMessage {
+
+        const text: string = `🚀 Welcome to the Subatomic environment *${firstName}*!\n\n` +
+            `${secondarySlackChannels.length > 0 ? `You have been added to the Subatomic community channel/s:\n *${secondarySlackChannels.join("*\n*")}*\n\n` : "\n\n"}` +
+            `Next steps are to either join an existing team or create a new one.`;
 
         return {
             text,

--- a/src/gluon/services/member/OnboardMemberService.ts
+++ b/src/gluon/services/member/OnboardMemberService.ts
@@ -1,0 +1,36 @@
+import {HandlerContext, logger} from "@atomist/automation-client";
+import {
+    addressSlackChannelsFromContext,
+} from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/lib/handlers/command/slack/AssociateRepo";
+import {QMError} from "../../util/shared/Error";
+import {loadChannelIdByChannelName} from "../../util/team/Teams";
+
+export class OnboardMemberService {
+
+    public async inviteUserToSecondarySlackChannel(ctx: HandlerContext,
+                                                   newMemberFirstName: string,
+                                                   channelName: string,
+                                                   slackUserID: string,
+                                                   slackScreenName: string) {
+
+        const destination = await addressSlackChannelsFromContext(ctx, channelName);
+        try {
+            logger.info(`Added team member! Inviting to channel [${channelName}] -> member [${slackUserID}]`);
+            const slackChannelId = await loadChannelIdByChannelName(ctx, channelName);
+            logger.info("Channel ID: " + slackChannelId);
+
+            await inviteUserToSlackChannel(ctx,
+                destination.team, // NOTE: this is the Slack Workspace ID not the Atomist Workspace ID (they used to be the same)
+                slackChannelId,
+                slackUserID);
+
+            return channelName;
+        } catch (error) {
+            logger.warn(`inviteUserToCustomSlackChannel warning: ${JSON.stringify(error)}`);
+            const msg = `Invitation to channel *${channelName}* failed for *${slackScreenName}*.\n Note, private channels do not currently support automatic user invitation.\n` +
+                `Please invite the user to this slack channel manually.`;
+            throw new QMError(msg);
+        }
+    }
+}

--- a/src/gluon/services/member/OnboardMemberService.ts
+++ b/src/gluon/services/member/OnboardMemberService.ts
@@ -3,7 +3,6 @@ import {
     addressSlackChannelsFromContext,
 } from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/lib/handlers/command/slack/AssociateRepo";
-import {QMError} from "../../util/shared/Error";
 import {loadChannelIdByChannelName} from "../../util/team/Teams";
 
 export class OnboardMemberService {
@@ -30,7 +29,7 @@ export class OnboardMemberService {
             logger.warn(`inviteUserToCustomSlackChannel warning: ${JSON.stringify(error)}`);
             const msg = `Invitation to channel *${channelName}* failed for *${slackScreenName}*.\n Note, private channels do not currently support automatic user invitation.\n` +
                 `Please invite the user to this slack channel manually.`;
-            throw new QMError(msg);
+            return await ctx.messageClient.send(msg, destination);
         }
     }
 }

--- a/test/gluon/commands/member/OnboardMemberTest.ts
+++ b/test/gluon/commands/member/OnboardMemberTest.ts
@@ -10,17 +10,22 @@ import {TestMessageClient} from "../../TestMessageClient";
 const MockAdapter = require("axios-mock-adapter");
 
 describe("Onboard new member test", () => {
-    it("should welcome new user", async () => {
+
+    it("should welcome new user (no secondary channels)", async () => {
+
+        QMConfig.secondarySlackChannels = [];
+
         const axiosWrapper = new AwaitAxios();
         const mock = new MockAdapter(axiosWrapper.axiosInstance);
 
         mock.onPost(`${QMConfig.subatomic.gluon.baseUrl}/members`).reply(201, {
-            firstName: "Test",
+            firstName: "Wang1",
             lastName: "User",
             email: "test.user@foo.co.za",
             domainUsername: "tete528",
+
             slack: {
-                screenName: "test.user",
+                screenName: "Jason",
                 userId: "9USDA7D6dH",
             },
         });
@@ -30,9 +35,10 @@ describe("Onboard new member test", () => {
         const subject = new OnboardMember(gluonService);
         subject.domainUsername = "tete528";
         subject.email = "test.user@foo.co.za";
-        subject.firstName = "Test";
+        subject.firstName = "Wang1";
         subject.userId = "9USDA7D6dH";
         subject.lastName = "User";
+        subject.screenName = "Jason";
 
         const fakeContext = {
             teamId: "TEST",
@@ -42,9 +48,38 @@ describe("Onboard new member test", () => {
             graphClient: new TestGraphClient(),
         };
 
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "1234"}]}});
+        // fake results from inner methods
+        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "TCZLW7AT0"}]}});
+
+        fakeContext.graphClient.executeQueryResults.push({
+            result: true,
+            returnValue: {
+                ChatChannel: [{
+                    id: "AI6DFNN4K_CFN59SHPY",
+                    name: "subatomic-discussion",
+                    channelId: "CFN59SHPY",
+                }],
+            },
+        });
+
+        fakeContext.graphClient.executeQueryResults.push({
+            result: true,
+            returnValue: {inviteUserToSlackChannel: {id: "CFN59SHPY"}},
+        });
+
+        fakeContext.graphClient.executeQueryResults.push({
+            result: true,
+            returnValue: {
+                SlackDestination: {
+                    team: "TCZLW7AT0",
+                    userAgent: "slack",
+                    users: ["UE8SGB4QK"],
+                    channels: ["abc", "def"],
+                },
+            },
+        });
 
         await subject.handle(fakeContext);
-        assert(fakeContext.messageClient.textMsg[0].text.trim() === "Welcome to the Subatomic environment *Test*!\nNext steps are to either join an existing team or create a new one.");
+        assert(fakeContext.messageClient.textMsg[0].text.trim() === "🚀 Welcome to the Subatomic environment *Wang1*!\n\n\n\nNext steps are to either join an existing team or create a new one.");
     });
 });

--- a/test/gluon/services/member/OnboardMemberServiceTest.ts
+++ b/test/gluon/services/member/OnboardMemberServiceTest.ts
@@ -1,8 +1,8 @@
 import {url} from "@atomist/slack-messages";
 import assert = require("power-assert");
+import {OnboardMemberService} from "../../../../src/gluon/services/member/OnboardMemberService";
 import {TestGraphClient} from "../../TestGraphClient";
 import {TestMessageClient} from "../../TestMessageClient";
-import {OnboardMemberService} from "../../../../src/gluon/services/member/OnboardMemberService";
 
 describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
 
@@ -32,7 +32,45 @@ describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
             "Howard",
         );
 
-        assert.equal(fakeContext.messageClient.textMsg[0], `Invitation to channel *channel1* failed for *Howard*.\nNote, private channels do not currently support automatic user invitation.\n` +
-            `Please invite the user to this slack channel manually.`);
+        assert.equal(fakeContext.messageClient.textMsg[0], "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
+    });
+
+    it("should invite user to custom slack channel and return channel name", async () => {
+
+        const service = new OnboardMemberService();
+
+        const fakeContext = {
+            teamId: "TEST",
+            correlationId: "1231343234234",
+            workspaceId: "2341234123",
+            messageClient: new TestMessageClient(),
+            graphClient: new TestGraphClient(),
+        };
+
+        // fake results from inner methods
+        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "TCZLW7AT0"}]}});
+        fakeContext.graphClient.executeQueryResults.push({
+            result: true,
+            returnValue: {
+                ChatChannel: [{
+                    id: "AI6DFNN4K_CFN59SHPY",
+                    name: "subatomic-discussion",
+                    channelId: "CFN59SHPY",
+                }],
+            },
+        });
+        fakeContext.graphClient.executeMutationResults.push({
+            result: true,
+            returnValue: {inviteUserToSlackChannel: {id: "CFN59SHPY"}},
+        });
+
+        const res = await service.inviteUserToSecondarySlackChannel(fakeContext,
+            "Jude",
+            "channel1",
+            "channe1id",
+            "Howard",
+        );
+
+        assert.equal(res, `channel1`);
     });
 });

--- a/test/gluon/services/member/OnboardMemberServiceTest.ts
+++ b/test/gluon/services/member/OnboardMemberServiceTest.ts
@@ -1,0 +1,38 @@
+import {url} from "@atomist/slack-messages";
+import assert = require("power-assert");
+import {TestGraphClient} from "../../TestGraphClient";
+import {TestMessageClient} from "../../TestMessageClient";
+import {OnboardMemberService} from "../../../../src/gluon/services/member/OnboardMemberService";
+
+describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
+
+    it("should fail to invite user to custom slack channel 400 (private channel type error)", async () => {
+
+        const service = new OnboardMemberService();
+
+        const fakeContext = {
+            teamId: "TEST",
+            correlationId: "1231343234234",
+            workspaceId: "2341234123",
+            messageClient: new TestMessageClient(),
+            graphClient: new TestGraphClient(),
+        };
+
+        // Force invite to fail
+        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "1234"}]}});
+        fakeContext.graphClient.executeMutationResults.push({
+            result: false,
+            returnValue: {networkError: {statusCode: 400}},
+        });
+
+        await service.inviteUserToSecondarySlackChannel(fakeContext,
+            "Jude",
+            "channel1",
+            "channe1id",
+            "Howard",
+        );
+
+        assert.equal(fakeContext.messageClient.textMsg[0], `Invitation to channel *channel1* failed for *Howard*.\nNote, private channels do not currently support automatic user invitation.\n` +
+            `Please invite the user to this slack channel manually.`);
+    });
+});


### PR DESCRIPTION
### Description
Secondary channels can now be added to the QM config so when a user is on-boarded they get invited to these channels.

### Essential Checks:

* [x] Have you added tests where necessary?
NOTE: The onboard me test is failing but I have raised task: onboard me test is failing with new community channels #655 to INVESTIGATE with Kieran later
* [x] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [x] Have you added new commands to the displayable Help list?
* [x] Have you updated any necessary documentation?
