### PR TITLE
Add restrictions to team names to be within 1->22

### DIFF
--- a/src/gluon/commands/team/CreateTeam.ts
+++ b/src/gluon/commands/team/CreateTeam.ts
@@ -33,6 +33,8 @@ export class CreateTeam extends RecursiveParameterRequestCommand implements Gluo
 
     @Parameter({
         description: "team name",
+        pattern: /.{1,22}/,
+        validInput: "between 1->22 characters",
     })
     public teamName: string;
 


### PR DESCRIPTION
### Description
Bug fix of Slack not allowing channel names above 22 characters. Restricted team names to be within this restriction.

### Essential Checks:

* [x] Have you added tests where necessary?
* [x] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [x] Have you added new commands to the displayable Help list?
* [x] Have you updated any necessary documentation?
