### PR TITLE
Config server event handler

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -59,6 +59,10 @@ import {ProjectProductionEnvironmentsRequestClosed} from "./gluon/events/project
 import {ProjectProductionEnvironmentsRequested} from "./gluon/events/project/ProjectProductionEnvironmentsRequested";
 import {TeamsLinkedToProject} from "./gluon/events/project/TeamAssociated";
 import {BotJoinedChannel} from "./gluon/events/team/BotJoinedChannel";
+import {
+    ConfigServerRequested,
+    ConfigServerRequestedEvent,
+} from "./gluon/events/team/ConfigServerRequested";
 import {DevOpsEnvironmentRequested} from "./gluon/events/team/DevOpsEnvironmentRequested";
 import {MemberRemovedFromTeam} from "./gluon/events/team/MemberRemovedFromTeam";
 import {MembersAddedToTeam} from "./gluon/events/team/MembersAddedToTeam";
@@ -125,6 +129,7 @@ export const configuration: any = {
         ApplicationProdRequested,
         BitbucketProjectAdded,
         BotJoinedChannel,
+        ConfigServerRequested,
         DevOpsEnvironmentRequested,
         GenericProdRequested,
         MemberRemovedFromTeam,
@@ -177,6 +182,7 @@ export const configuration: any = {
         ingester("ProjectProductionEnvironmentsRequestedEvent"),
         ingester("ProjectProductionEnvironmentsRequestClosedEvent"),
         ingester("PackageConfigurationRequestedEvent"),
+        ingester("ConfigServerRequestedEvent"),
     ],
     apiKey,
     http,

--- a/src/gluon/commands/team/AddConfigServer.ts
+++ b/src/gluon/commands/team/AddConfigServer.ts
@@ -1,23 +1,24 @@
 import {
+    addressEvent,
     HandlerContext,
     HandlerResult,
-    logger,
     Parameter,
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
-import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
-import {SlackMessage, url} from "@atomist/slack-messages";
-import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
+import {ConfigServerRequestedEvent} from "../../events/team/ConfigServerRequested";
 import {GluonService} from "../../services/gluon/GluonService";
-import {OCService} from "../../services/openshift/OCService";
+import {QMMemberBase} from "../../util/member/Members";
 import {
     GluonTeamNameParam,
-    GluonTeamNameSetter, GluonTeamOpenShiftCloudParam,
+    GluonTeamNameSetter,
+    GluonTeamOpenShiftCloudParam,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {QMTeam} from "../../util/team/Teams";
+import {GluonToEvent} from "../../util/transform/GluonToEvent";
 
 @CommandHandler("Add a new Subatomic Config Server", QMConfig.subatomic.commandPrefix + " add config server")
 @Tags("subatomic", "team")
@@ -40,17 +41,16 @@ export class AddConfigServer extends RecursiveParameterRequestCommand
     })
     public gitUri: string;
 
-    constructor(public gluonService = new GluonService(),
-                private ocService = new OCService()) {
+    constructor(public gluonService = new GluonService()) {
         super();
     }
 
     protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
         try {
-            await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd);
             return await this.addConfigServer(
                 ctx,
                 this.teamName,
+                this.screenName,
                 this.gitUri,
             );
         } catch (error) {
@@ -61,111 +61,19 @@ export class AddConfigServer extends RecursiveParameterRequestCommand
 
     private async addConfigServer(ctx: HandlerContext,
                                   gluonTeamName: string,
+                                  actionedByScreenName: string,
                                   gitUri: string): Promise<any> {
-        try {
-            const devOpsProjectId = `${_.kebabCase(gluonTeamName).toLowerCase()}-devops`;
-            await this.addConfigServerSecretToDevOpsEnvironment(devOpsProjectId);
+        const team: QMTeam = await this.gluonService.teams.gluonTeamByName(gluonTeamName);
+        const actionedBy: QMMemberBase = await this.gluonService.members.gluonMemberFromScreenName(actionedByScreenName);
 
-            await this.createConfigServerConfigurationMap(devOpsProjectId);
-
-            await this.tagConfigServerImageToDevOpsEnvironment(devOpsProjectId);
-
-            await this.addViewRoleToDevOpsEnvironmentDefaultServiceAccount(devOpsProjectId);
-
-            await this.createConfigServerDeploymentConfig(gitUri, devOpsProjectId);
-
-            await this.sendSuccessResponse(ctx, devOpsProjectId);
-            this.succeedCommand();
-        } catch (error) {
-            this.failCommand();
-            return await handleQMError(new ResponderMessageClient(ctx), error);
-        }
-    }
-
-    private async addConfigServerSecretToDevOpsEnvironment(devOpsProjectId: string) {
-        try {
-            await this.ocService.createConfigServerSecret(devOpsProjectId);
-        } catch (error) {
-            logger.warn("Secret subatomic-config-server probably already exists");
-        }
-    }
-
-    private async createConfigServerConfigurationMap(devOpsProjectId: string) {
-        const configurationMapDefintion = {
-            apiVersion: "v1",
-            kind: "ConfigMap",
-            metadata: {
-                name: "subatomic-config-server",
-            },
-            data: {
-                "application.yml": `
-spring:
-  cloud:
-    config:
-      server:
-        git:
-          ignoreLocalSshSettings: true
-          strictHostKeyChecking: false
-          hostKeyAlgorithm: ssh-rsa
-`,
-            },
-        };
-        return await this.ocService.applyResourceFromDataInNamespace(configurationMapDefintion, devOpsProjectId);
-    }
-
-    private async tagConfigServerImageToDevOpsEnvironment(devOpsProjectId: string) {
-        return await this.ocService.tagSubatomicImageToNamespace(
-            "subatomic-config-server:3.0",
-            devOpsProjectId,
-            "subatomic-config-server:3.0");
-    }
-
-    private async addViewRoleToDevOpsEnvironmentDefaultServiceAccount(devOpsProjectId: string) {
-        return await this.ocService.addRoleToUserInNamespace(
-            `system:serviceaccount:${devOpsProjectId}:default`,
-            "view",
-            devOpsProjectId);
-    }
-
-    private async createConfigServerDeploymentConfig(gitUri: string, devOpsProjectId: string) {
-        try {
-            await this.ocService.getDeploymentConfigInNamespace("subatomic-config-server", devOpsProjectId);
-            logger.warn(`Subatomic Config Server Template has already been processed, deployment exists`);
-        } catch (error) {
-            const saneGitUri = _.replace(gitUri, /(<)|>/g, "");
-
-            const templateParameters = [
-                {key: "GIT_URI", value: saneGitUri},
-                {key: "IMAGE_STREAM_PROJECT", value: devOpsProjectId},
-            ];
-
-            const appTemplate = await this.ocService.findAndProcessOpenshiftTemplate(
-                "subatomic-config-server-template",
-                "subatomic",
-                templateParameters);
-
-            logger.debug(`Processed Subatomic Config Server Template: ${JSON.stringify(appTemplate)}`);
-
-            await this.ocService.applyResourceFromDataInNamespace(appTemplate, devOpsProjectId);
-        }
-    }
-
-    private async sendSuccessResponse(ctx: HandlerContext, devOpsProjectId: string) {
-        const destination = await addressSlackChannelsFromContext(ctx, this.teamChannel);
-        const slackMessage: SlackMessage = {
-            text: `Your Subatomic Config Server has been added to your *${devOpsProjectId}* OpenShift project successfully`,
-            attachments: [{
-                fallback: `Your Subatomic Config Server has been added successfully`,
-                footer: `For more information, please read the ${this.docs()}`,
-            }],
+        const requestConfigServerEvent: ConfigServerRequestedEvent = {
+            team: GluonToEvent.team(team),
+            actionedBy: GluonToEvent.member(actionedBy),
+            configRepositoryGitURI: gitUri,
         };
 
-        return await ctx.messageClient.send(slackMessage, destination);
-    }
-
-    private docs(): string {
-        return `${url(`${QMConfig.subatomic.docs.baseUrl}/config-server`,
-            "documentation")}`;
+        await ctx.messageClient.send(requestConfigServerEvent, addressEvent("ConfigServerRequestedEvent"));
+        await ctx.messageClient.respond("Requesting Config Server...");
     }
 
 }

--- a/src/gluon/events/packages/PackageConfigurationRequested.ts
+++ b/src/gluon/events/packages/PackageConfigurationRequested.ts
@@ -29,9 +29,9 @@ import {
     QMMessageClient,
 } from "../../util/shared/Error";
 import {isUserAMemberOfTheTeam, QMTeam} from "../../util/team/Teams";
-import {ActionedByEvent} from "../../util/transform/types/event/ActionedByEvent";
 import {GluonApplicationEvent} from "../../util/transform/types/event/GluonApplicationEvent";
 import {KeyValuePairEvent} from "../../util/transform/types/event/KeyValuePairEvent";
+import {MemberEvent} from "../../util/transform/types/event/MemberEvent";
 import {ProjectEvent} from "../../util/transform/types/event/ProjectEvent";
 
 @EventHandler("Receive PackageConfigurationRequested events", `
@@ -191,5 +191,5 @@ export interface PackageConfigurationRequestedEvent {
     jenkinsfileName: string;
     buildEnvironmentVariables: KeyValuePairEvent[];
     deploymentEnvironmentVariables: KeyValuePairEvent[];
-    actionedBy: ActionedByEvent;
+    actionedBy: MemberEvent;
 }

--- a/src/gluon/events/team/ConfigServerRequested.ts
+++ b/src/gluon/events/team/ConfigServerRequested.ts
@@ -1,0 +1,175 @@
+import {
+    EventFired,
+    HandlerContext,
+    HandlerResult,
+    logger,
+} from "@atomist/automation-client";
+import {EventHandler} from "@atomist/automation-client/lib/decorators";
+import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
+import {SlackMessage, url} from "@atomist/slack-messages";
+import * as _ from "lodash";
+import {QMConfig} from "../../../config/QMConfig";
+import {GluonService} from "../../services/gluon/GluonService";
+import {OCService} from "../../services/openshift/OCService";
+import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
+import {
+    ChannelMessageClient,
+    handleQMError,
+    QMMessageClient,
+} from "../../util/shared/Error";
+import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
+import {GluonTeamEvent} from "../../util/transform/types/event/GluonTeamEvent";
+import {MemberEvent} from "../../util/transform/types/event/MemberEvent";
+
+@EventHandler("Receive ConfigServerRequested events", `
+subscription ConfigServerRequestedEvent {
+  ConfigServerRequestedEvent {
+    id
+    team{
+      name
+      openShiftCloud
+      slackIdentity {
+        teamChannel
+      }
+    }
+    actionedBy{
+      firstName
+      slackIdentity {
+        screenName
+      }
+    }
+    configRepositoryGitURI
+  }
+}
+`)
+export class ConfigServerRequested extends BaseQMEvent implements HandleEvent<any> {
+
+    constructor(private gluonService: GluonService = new GluonService(),
+                private ocService = new OCService()) {
+        super();
+    }
+
+    public async handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
+        logger.info(`Ingested ConfigServerRequested event: ${JSON.stringify(event.data)}`);
+        const configServerRequestedEvent: ConfigServerRequestedEvent = event.data.ConfigServerRequestedEvent[0];
+
+        const messageClient: QMMessageClient = new ChannelMessageClient(ctx).addDestination(configServerRequestedEvent.team.slackIdentity.teamChannel);
+
+        try {
+            await this.addConfigServer(configServerRequestedEvent.team.name, configServerRequestedEvent.team.openShiftCloud, configServerRequestedEvent.configRepositoryGitURI);
+            this.succeedEvent();
+            return await this.sendSuccessResponse(messageClient, configServerRequestedEvent.team.name);
+        } catch (error) {
+            this.failEvent();
+            return await handleQMError(messageClient, error);
+        }
+    }
+
+    private async addConfigServer(gluonTeamName: string,
+                                  openShiftCloud: string,
+                                  gitUri: string): Promise<any> {
+        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[openShiftCloud].openshiftNonProd);
+        const devOpsProjectId = getDevOpsEnvironmentDetails(gluonTeamName).openshiftProjectId;
+        await this.addConfigServerSecretToDevOpsEnvironment(devOpsProjectId);
+
+        await this.createConfigServerConfigurationMap(devOpsProjectId);
+
+        await this.tagConfigServerImageToDevOpsEnvironment(devOpsProjectId);
+
+        await this.addViewRoleToDevOpsEnvironmentDefaultServiceAccount(devOpsProjectId);
+
+        await this.createConfigServerDeploymentConfig(gitUri, devOpsProjectId);
+    }
+
+    private async addConfigServerSecretToDevOpsEnvironment(devOpsProjectId: string) {
+        try {
+            await this.ocService.createConfigServerSecret(devOpsProjectId);
+        } catch (error) {
+            logger.warn("Secret subatomic-config-server probably already exists");
+        }
+    }
+
+    private async createConfigServerConfigurationMap(devOpsProjectId: string) {
+        const configurationMapDefintion = {
+            apiVersion: "v1",
+            kind: "ConfigMap",
+            metadata: {
+                name: "subatomic-config-server",
+            },
+            data: {
+                "application.yml": `
+spring:
+  cloud:
+    config:
+      server:
+        git:
+          ignoreLocalSshSettings: true
+          strictHostKeyChecking: false
+          hostKeyAlgorithm: ssh-rsa
+`,
+            },
+        };
+        return await this.ocService.applyResourceFromDataInNamespace(configurationMapDefintion, devOpsProjectId);
+    }
+
+    private async tagConfigServerImageToDevOpsEnvironment(devOpsProjectId: string) {
+        return await this.ocService.tagSubatomicImageToNamespace(
+            "subatomic-config-server:3.0",
+            devOpsProjectId,
+            "subatomic-config-server:3.0");
+    }
+
+    private async addViewRoleToDevOpsEnvironmentDefaultServiceAccount(devOpsProjectId: string) {
+        return await this.ocService.addRoleToUserInNamespace(
+            `system:serviceaccount:${devOpsProjectId}:default`,
+            "view",
+            devOpsProjectId);
+    }
+
+    private async createConfigServerDeploymentConfig(gitUri: string, devOpsProjectId: string) {
+        try {
+            await this.ocService.getDeploymentConfigInNamespace("subatomic-config-server", devOpsProjectId);
+            logger.warn(`Subatomic Config Server Template has already been processed, deployment exists`);
+        } catch (error) {
+            const saneGitUri = _.replace(gitUri, /(<)|>/g, "");
+
+            const templateParameters = [
+                {key: "GIT_URI", value: saneGitUri},
+                {key: "IMAGE_STREAM_PROJECT", value: devOpsProjectId},
+            ];
+
+            const appTemplate = await this.ocService.findAndProcessOpenshiftTemplate(
+                "subatomic-config-server-template",
+                "subatomic",
+                templateParameters);
+
+            logger.debug(`Processed Subatomic Config Server Template: ${JSON.stringify(appTemplate)}`);
+
+            await this.ocService.applyResourceFromDataInNamespace(appTemplate, devOpsProjectId);
+        }
+    }
+
+    private async sendSuccessResponse(messageClient: QMMessageClient, gluonTeamName: string) {
+        const devOpsProjectId = getDevOpsEnvironmentDetails(gluonTeamName).openshiftProjectId;
+        const slackMessage: SlackMessage = {
+            text: `Your Subatomic Config Server has been added to your *${devOpsProjectId}* OpenShift project successfully`,
+            attachments: [{
+                fallback: `Your Subatomic Config Server has been added successfully`,
+                footer: `For more information, please read the ${this.docs()}`,
+            }],
+        };
+
+        return await messageClient.send(slackMessage);
+    }
+
+    private docs(): string {
+        return `${url(`${QMConfig.subatomic.docs.baseUrl}/quantum-mechanic/command-reference`,
+            "documentation")}`;
+    }
+}
+
+export interface ConfigServerRequestedEvent {
+    team: GluonTeamEvent;
+    actionedBy: MemberEvent;
+    configRepositoryGitURI: string;
+}

--- a/src/gluon/tasks/team/CreateConfigServer.ts
+++ b/src/gluon/tasks/team/CreateConfigServer.ts
@@ -1,0 +1,127 @@
+import {HandlerContext, logger} from "@atomist/automation-client";
+import * as _ from "lodash";
+import {QMConfig} from "../../../config/QMConfig";
+import {OCService} from "../../services/openshift/OCService";
+import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
+import {Task} from "../Task";
+import {TaskListMessage} from "../TaskListMessage";
+
+export class CreateConfigServer extends Task {
+
+    private readonly TASK_CONFIG_SERVER_SECRET = TaskListMessage.createUniqueTaskName("ConfigServerSecret");
+    private readonly TASK_CONFIG_SERVER_CONFIG_MAP = TaskListMessage.createUniqueTaskName("ConfigServerConfigMap");
+    private readonly TASK_TAG_CONFIG_SERVER_IMAGE = TaskListMessage.createUniqueTaskName("TagImage");
+    private readonly TASK_SET_SERVICE_ACCOUNT_PERMISSIONS = TaskListMessage.createUniqueTaskName("ServiceAccountPermissions");
+    private readonly TASK_CREATE_DEPLOYMENT_CONFIG = TaskListMessage.createUniqueTaskName("DeploymentConfig");
+
+    constructor(private gluonTeamName,
+                private openShiftCloud,
+                private gitRepoSSHURI,
+                private ocService = new OCService()) {
+        super();
+    }
+
+    protected configureTaskListMessage(taskListMessage: TaskListMessage) {
+        taskListMessage.addTask(this.TASK_CONFIG_SERVER_SECRET, `\tCreate Config Server Secret`);
+        taskListMessage.addTask(this.TASK_CONFIG_SERVER_CONFIG_MAP, `\tCreate Config Server Config Map`);
+        taskListMessage.addTask(this.TASK_TAG_CONFIG_SERVER_IMAGE, `\tTag Config Server image to DevOps`);
+        taskListMessage.addTask(this.TASK_SET_SERVICE_ACCOUNT_PERMISSIONS, `\tGrant Service Account correct permissions`);
+        taskListMessage.addTask(this.TASK_CREATE_DEPLOYMENT_CONFIG, `\tCreate Config Server Deployment Config`);
+    }
+
+    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+
+        await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd);
+        const devOpsProjectId = getDevOpsEnvironmentDetails(this.gluonTeamName).openshiftProjectId;
+        await this.addConfigServerSecretToDevOpsEnvironment(devOpsProjectId);
+
+        await this.taskListMessage.succeedTask(this.TASK_CONFIG_SERVER_SECRET);
+
+        await this.createConfigServerConfigurationMap(devOpsProjectId);
+
+        await this.taskListMessage.succeedTask(this.TASK_CONFIG_SERVER_CONFIG_MAP);
+
+        await this.tagConfigServerImageToDevOpsEnvironment(devOpsProjectId);
+
+        await this.taskListMessage.succeedTask(this.TASK_TAG_CONFIG_SERVER_IMAGE);
+
+        await this.addViewRoleToDevOpsEnvironmentDefaultServiceAccount(devOpsProjectId);
+
+        await this.taskListMessage.succeedTask(this.TASK_SET_SERVICE_ACCOUNT_PERMISSIONS);
+
+        await this.createConfigServerDeploymentConfig(this.gitRepoSSHURI, devOpsProjectId);
+
+        await this.taskListMessage.succeedTask(this.TASK_CREATE_DEPLOYMENT_CONFIG);
+
+        return true;
+    }
+
+    private async addConfigServerSecretToDevOpsEnvironment(devOpsProjectId: string) {
+        try {
+            await this.ocService.createConfigServerSecret(devOpsProjectId);
+        } catch (error) {
+            logger.warn("Secret subatomic-config-server probably already exists");
+        }
+    }
+
+    private async createConfigServerConfigurationMap(devOpsProjectId: string) {
+        const configurationMapDefintion = {
+            apiVersion: "v1",
+            kind: "ConfigMap",
+            metadata: {
+                name: "subatomic-config-server",
+            },
+            data: {
+                "application.yml": `
+spring:
+  cloud:
+    config:
+      server:
+        git:
+          ignoreLocalSshSettings: true
+          strictHostKeyChecking: false
+          hostKeyAlgorithm: ssh-rsa
+`,
+            },
+        };
+        return await this.ocService.applyResourceFromDataInNamespace(configurationMapDefintion, devOpsProjectId);
+    }
+
+    private async tagConfigServerImageToDevOpsEnvironment(devOpsProjectId: string) {
+        return await this.ocService.tagSubatomicImageToNamespace(
+            "subatomic-config-server:3.0",
+            devOpsProjectId,
+            "subatomic-config-server:3.0");
+    }
+
+    private async addViewRoleToDevOpsEnvironmentDefaultServiceAccount(devOpsProjectId: string) {
+        return await this.ocService.addRoleToUserInNamespace(
+            `system:serviceaccount:${devOpsProjectId}:default`,
+            "view",
+            devOpsProjectId);
+    }
+
+    private async createConfigServerDeploymentConfig(gitUri: string, devOpsProjectId: string) {
+        try {
+            await this.ocService.getDeploymentConfigInNamespace("subatomic-config-server", devOpsProjectId);
+            logger.warn(`Subatomic Config Server Template has already been processed, deployment exists`);
+        } catch (error) {
+            const saneGitUri = _.replace(gitUri, /(<)|>/g, "");
+
+            const templateParameters = [
+                {key: "GIT_URI", value: saneGitUri},
+                {key: "IMAGE_STREAM_PROJECT", value: devOpsProjectId},
+            ];
+
+            const appTemplate = await this.ocService.findAndProcessOpenshiftTemplate(
+                "subatomic-config-server-template",
+                "subatomic",
+                templateParameters);
+
+            logger.debug(`Processed Subatomic Config Server Template: ${JSON.stringify(appTemplate)}`);
+
+            await this.ocService.applyResourceFromDataInNamespace(appTemplate, devOpsProjectId);
+        }
+    }
+
+}

--- a/src/gluon/util/team/Teams.ts
+++ b/src/gluon/util/team/Teams.ts
@@ -90,6 +90,7 @@ export interface QMTeamBase {
     teamId: string;
     name: string;
     openShiftCloud: string;
+    description: string;
     slack?: QMTeamSlack;
 }
 

--- a/src/gluon/util/transform/EventToGluon.ts
+++ b/src/gluon/util/transform/EventToGluon.ts
@@ -1,15 +1,30 @@
+import {QMMemberBase} from "../member/Members";
 import {QMTeam} from "../team/Teams";
+import {GluonTeamEvent} from "./types/event/GluonTeamEvent";
+import {MemberEvent} from "./types/event/MemberEvent";
 
 export class EventToGluon {
 
-    public static gluonTeam(eventTeam): QMTeam {
+    public static gluonTeam(eventTeam: GluonTeamEvent): QMTeam {
         return {
             teamId: eventTeam.teamId,
             name: eventTeam.name,
             openShiftCloud: eventTeam.openShiftCloud,
             slack: eventTeam.slackIdentity,
-            owners: eventTeam.owners,
-            members: eventTeam.members,
+            owners: eventTeam.owners.map(owner => EventToGluon.gluonMember(owner)),
+            members: eventTeam.members.map(member => EventToGluon.gluonMember(member)),
+            description: eventTeam.description,
+        };
+    }
+
+    public static gluonMember(eventMember: MemberEvent): QMMemberBase {
+        return {
+            firstName: eventMember.firstName,
+            lastName: eventMember.lastName,
+            email: eventMember.email,
+            domainUsername: eventMember.domainUsername,
+            memberId: eventMember.memberId,
+            slack: eventMember.slackIdentity,
         };
     }
 }

--- a/src/gluon/util/transform/GluonToEvent.ts
+++ b/src/gluon/util/transform/GluonToEvent.ts
@@ -2,10 +2,11 @@ import {QMApplication} from "../../services/gluon/ApplicationService";
 import {QMMemberBase} from "../member/Members";
 import {QMProject} from "../project/Project";
 import {QMTeam, QMTeamBase} from "../team/Teams";
-import {ActionedByEvent} from "./types/event/ActionedByEvent";
 import {GluonApplicationEvent} from "./types/event/GluonApplicationEvent";
 import {KeyValuePairEvent} from "./types/event/KeyValuePairEvent";
+import {MemberEvent} from "./types/event/MemberEvent";
 import {ProjectEvent} from "./types/event/ProjectEvent";
+import {SlackIdentityTeamEvent} from "./types/event/SlackIdentityTeamEvent";
 
 export class GluonToEvent {
 
@@ -51,6 +52,8 @@ export class GluonToEvent {
             teamId: gluonTeam.teamId,
             name: gluonTeam.name,
             slackIdentity: gluonTeam.slack,
+            openShiftCloud: gluonTeam.openShiftCloud,
+            description: gluonTeam.description,
         };
     }
 
@@ -58,13 +61,15 @@ export class GluonToEvent {
         return {
             teamId: gluonTeamFull.teamId,
             name: gluonTeamFull.name,
-            slackIdentity: gluonTeamFull.slack,
+            slackIdentity: gluonTeamFull.slack as SlackIdentityTeamEvent,
             owners: gluonTeamFull.owners,
             members: gluonTeamFull.members,
+            openShiftCloud: gluonTeamFull.openShiftCloud,
+            description: gluonTeamFull.description,
         };
     }
 
-    public static member(gluonMember: QMMemberBase): ActionedByEvent {
+    public static member(gluonMember: QMMemberBase): MemberEvent {
         return {
             memberId: gluonMember.memberId,
             firstName: gluonMember.firstName,

--- a/src/gluon/util/transform/types/event/GluonTeamEvent.ts
+++ b/src/gluon/util/transform/types/event/GluonTeamEvent.ts
@@ -1,0 +1,12 @@
+import {MemberEvent} from "./MemberEvent";
+import {SlackIdentityTeamEvent} from "./SlackIdentityTeamEvent";
+
+export interface GluonTeamEvent {
+    teamId: string;
+    name: string;
+    description: string;
+    slackIdentity: SlackIdentityTeamEvent;
+    openShiftCloud: string;
+    owners: MemberEvent[];
+    members: MemberEvent[];
+}

--- a/src/gluon/util/transform/types/event/MemberEvent.ts
+++ b/src/gluon/util/transform/types/event/MemberEvent.ts
@@ -1,6 +1,6 @@
 import {SlackIdentityMemberEvent} from "./SlackIdentityMemberEvent";
 
-export interface ActionedByEvent {
+export interface MemberEvent {
     memberId?: string;
     firstName?: string;
     lastName?: string;

--- a/src/gluon/util/transform/types/event/SlackIdentityTeamEvent.ts
+++ b/src/gluon/util/transform/types/event/SlackIdentityTeamEvent.ts
@@ -1,0 +1,3 @@
+export interface SlackIdentityTeamEvent {
+    teamChannel: string;
+}

--- a/src/graphql/ingester/ConfigServerRequestedEvent.graphql
+++ b/src/graphql/ingester/ConfigServerRequestedEvent.graphql
@@ -1,0 +1,5 @@
+type ConfigServerRequestedEvent @rootType {
+    team: GluonTeam
+    actionedBy: ActionedBy
+    configRepositoryGitURI: String
+}


### PR DESCRIPTION
### Description
Moved the config server creation logic into an event handler/task runner configuration. This will allow config server requests from applications outside of slack.

Closes #693 

### Essential Checks:

* [X] Have you added tests where necessary?
* [X] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [X] Have you added new commands to the displayable Help list?
* [X] Have you updated any necessary documentation?
