### PR TITLE
Fix TeamChannel creation bug.

### DIFF
--- a/src/gluon/commands/team/NewOrExistingTeamSlackChannel.ts
+++ b/src/gluon/commands/team/NewOrExistingTeamSlackChannel.ts
@@ -21,13 +21,13 @@ export class NewOrUseTeamSlackChannel extends BaseQMComand implements HandleComm
         description: "team channel name",
         required: false,
     })
-    public teamChannel: string;
+    public newTeamChannel: string;
 
     public teamSlackChannelMessages = new TeamSlackChannelMessages();
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
-            const result =  await ctx.messageClient.respond(this.teamSlackChannelMessages.createNewOrUseExistingSlackChannel(this.teamChannel, this.teamName));
+            const result =  await ctx.messageClient.respond(this.teamSlackChannelMessages.createNewOrUseExistingSlackChannel(this.newTeamChannel, this.teamName));
             this.succeedCommand();
             return result;
         } catch (error) {

--- a/src/gluon/commands/team/NewSlackChannel.ts
+++ b/src/gluon/commands/team/NewSlackChannel.ts
@@ -31,7 +31,7 @@ export class NewTeamSlackChannel extends BaseQMComand implements HandleCommand {
         required: false,
         displayable: false,
     })
-    public teamChannel: string;
+    public newTeamChannel: string;
 
     constructor(private teamSlackChannelService = new TeamSlackChannelService()) {
         super();
@@ -39,8 +39,8 @@ export class NewTeamSlackChannel extends BaseQMComand implements HandleCommand {
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
-            this.teamChannel = _.isEmpty(this.teamChannel) ? this.teamName : this.teamChannel;
-            const result =  await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.teamChannel, "create-team-channel", true);
+            this.newTeamChannel = _.isEmpty(this.newTeamChannel) ? this.teamName : this.newTeamChannel;
+            const result = await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.newTeamChannel, "create-team-channel", true);
             this.succeedCommand();
             return result;
         } catch (error) {

--- a/src/gluon/events/team/TeamCreated.ts
+++ b/src/gluon/events/team/TeamCreated.ts
@@ -57,7 +57,7 @@ Next you should configure your team Slack channel and OpenShift DevOps environme
                         new NewOrUseTeamSlackChannel(),
                         {
                             teamName: teamCreatedEvent.team.name,
-                            teamChannel: _.kebabCase(teamCreatedEvent.team.name),
+                            newTeamChannel: _.kebabCase(teamCreatedEvent.team.name),
                         }),
                 ],
             }],

--- a/src/gluon/messages/team/TeamSlackChannelMessages.ts
+++ b/src/gluon/messages/team/TeamSlackChannelMessages.ts
@@ -47,7 +47,7 @@ rather use that instead?\
                         new NewTeamSlackChannel(),
                         {
                             teamName,
-                            teamChannel,
+                            newTeamChannel: teamChannel,
                         }),
                     buttonForCommand(
                         {text: "Use an existing channel"},


### PR DESCRIPTION
### Description
BugFix: Change the parameter name teamChannel to newTeamChannel when capturing slack channel names. Required otherwise it gets hidden by the BaseQMCommand teamChannel mapped parameter.

### Essential Checks:

* [X] Have you added tests where necessary?
* [X] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [X] Have you added new commands to the displayable Help list?
* [X] Have you updated any necessary documentation?
