### PR TITLE
Improve the latest tag finding functionality

### DIFF
--- a/resources/templates/jenkins/jenkinsfile-repo/jenkinsfile.deployment.groovy
+++ b/resources/templates/jenkins/jenkinsfile-repo/jenkinsfile.deployment.groovy
@@ -39,9 +39,19 @@ def getTag(projectId, imageStreamName, tag){
         echo "Requesting latest tag"
         openshift.withProject(projectId) {
             def imageStream = openshift.selector('imagestream', imageStreamName)
-            def newTag = imageStream.object().spec.tags[0].name
-            echo "Most recent tag found: $newTag"
-            return newTag
+            def availableTags = imageStream.object().status.tags
+            def latestTag;
+            def latestDate="0";
+            for (currentTag in availableTags){
+                for (tagItem in currentTag.items){
+                    if (tagItem.created.compareTo(latestDate) > 0){
+                        latestDate = tagItem.created;
+                        latestTag = currentTag.tag;
+                    }
+                }
+            }
+            echo "Most recent tag found: $latestTag"
+            return latestTag
         }
     }else {
         echo "Using tag: $tag"


### PR DESCRIPTION
### Description
Previous get latest tag looks in the wrong location to actually find the latest image tag. This fixes the issue.

### Essential Checks:

* [X] Have you added tests where necessary?
* [X] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [X] Have you added new commands to the displayable Help list?
* [X] Have you updated any necessary documentation?
