### PR TITLE
Added DevOps copying capabilities to migration

### DIFF
--- a/src/gluon/util/team/Teams.ts
+++ b/src/gluon/util/team/Teams.ts
@@ -42,11 +42,11 @@ export async function loadChannelIdByChannelName(ctx: HandlerContext, name: stri
     return null;
 }
 
-export function getDevOpsEnvironmentDetailsProd(teamName): DevOpsEnvironmentDetails {
+export function getDevOpsEnvironmentDetailsProd(teamName: string): DevOpsEnvironmentDetails {
     return getDevOpsEnvironmentDetails(teamName, "-prod");
 }
 
-export function getDevOpsEnvironmentDetails(teamName, postfix: string = ""): DevOpsEnvironmentDetails {
+export function getDevOpsEnvironmentDetails(teamName: string, postfix: string = ""): DevOpsEnvironmentDetails {
     return {
         openshiftProjectId: `${_.kebabCase(teamName).toLowerCase()}-devops${postfix}`,
         name: `${teamName} DevOps`,


### PR DESCRIPTION
### Description
Added DevOps copying capabilities to copy BC's and IS's so that application builds should work correctly when migrating.
Additionally added the deployment jenkins job creation for applications when migrating.

This needs to be properly tested when we have a proper two cluster environment up and running.

Closes #620, #730

### Essential Checks:

* [X] Have you added tests where necessary?
* [X] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [X] Have you added new commands to the displayable Help list?
* [X] Have you updated any necessary documentation?
