### PR TITLE
Buttons should dissapear after migration approval or cancellation #816

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,4 +267,4 @@ No versioning is in place at the time of creating this documentation
 This project is licensed under the Apache License v2.0 - see the LICENSE file for details
 
 <!-- ## Acknowledgements
-Hat tips to anyone inspiration. -->
+Hat tips to anyone inspirational. -->

--- a/src/gluon/commands/packages/CreateApplicationProd.ts
+++ b/src/gluon/commands/packages/CreateApplicationProd.ts
@@ -82,7 +82,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
         required: false,
         displayable: false,
     })
-    public approval: ApprovalEnum = ApprovalEnum.CONFIRM;
+    public approval: ApprovalEnum = ApprovalEnum.TO_CONFIRM;
 
     @Parameter({
         required: false,
@@ -107,7 +107,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
             const team = await this.gluonService.teams.gluonTeamByName(this.teamName);
             const qmMessageClient = new ChannelMessageClient(ctx).addDestination(team.slack.teamChannel);
 
-            if (this.approval === ApprovalEnum.CONFIRM) {
+            if (this.approval === ApprovalEnum.TO_CONFIRM) {
                 // Ensure the owning project is prod approved before proceeding
                 await assertApplicationProdCanBeRequested(this.projectName, this.deploymentPipelineId, this.gluonService);
 

--- a/src/gluon/commands/project/CreateGenericProd.ts
+++ b/src/gluon/commands/project/CreateGenericProd.ts
@@ -74,7 +74,7 @@ export class CreateGenericProd extends RecursiveParameterRequestCommand
         required: false,
         displayable: false,
     })
-    public approval: ApprovalEnum = ApprovalEnum.CONFIRM;
+    public approval: ApprovalEnum = ApprovalEnum.TO_CONFIRM;
 
     @Parameter({
         required: false,
@@ -99,7 +99,7 @@ export class CreateGenericProd extends RecursiveParameterRequestCommand
             const team = await this.gluonService.teams.gluonTeamByName(this.teamName);
             const qmMessageClient = new ChannelMessageClient(ctx).addDestination(team.slack.teamChannel);
 
-            if (this.approval === ApprovalEnum.CONFIRM) {
+            if (this.approval === ApprovalEnum.TO_CONFIRM) {
                 // Ensure project is prod approved before proceeding
                 await assertGenericProdCanBeRequested(this.projectName, this.deploymentPipelineId, this.gluonService);
 

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -55,7 +55,7 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
         required: false,
         displayable: false,
     })
-    public approval: ApprovalEnum = ApprovalEnum.CONFIRM;
+    public approval: ApprovalEnum = ApprovalEnum.TO_CONFIRM;
 
     @Parameter({
         required: false,
@@ -72,21 +72,21 @@ export class MigrateTeamCloud extends RecursiveParameterRequestCommand
             const team: QMTeam = await this.gluonService.teams.gluonTeamByName(this.teamName);
             const qmMessageClient = new ChannelMessageClient(ctx).addDestination(team.slack.teamChannel);
 
-            if (this.approval === ApprovalEnum.CONFIRM) {
-                this.correlationId = uuid();
+            if (this.approval === ApprovalEnum.TO_CONFIRM) {
+                this.correlationId = ctx.correlationId;
                 const message = this.confirmMigrationRequest(this);
 
                 return await qmMessageClient.send(message, {id: this.correlationId});
             } else if (this.approval === ApprovalEnum.APPROVED) {
 
                 const requestingMember: QMMemberBase = await this.gluonService.members.gluonMemberFromScreenName(this.screenName);
-
                 await this.gluonService.teams.updateTeamOpenShiftCloud(team.teamId, this.openShiftCloud, requestingMember.memberId);
 
                 this.succeedCommand();
 
-                return success();
+                return await qmMessageClient.send(this.getConfirmationResultMessage(this.approval), {id: this.correlationId});
             } else if (this.approval === ApprovalEnum.REJECTED) {
+
                 return await qmMessageClient.send(this.getConfirmationResultMessage(this.approval), {id: this.correlationId});
             }
 

--- a/src/gluon/util/shared/ApprovalEnum.ts
+++ b/src/gluon/util/shared/ApprovalEnum.ts
@@ -1,5 +1,5 @@
 export enum ApprovalEnum {
-    CONFIRM = "CONFIRM",
+    TO_CONFIRM = "TO_CONFIRM",
     APPROVED = "APPROVED",
     REJECTED = "REJECTED",
 }


### PR DESCRIPTION
### Description
The 'Approve Migration Request' and 'Cancel Migration Request' buttons now disappear after you approve or cancel a migration approval request. This will prevent double/over clicking by an impatient or overzealous user.

### Essential Checks:

* [x] Have you added tests where necessary?
* [x] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [x] Have you added new commands to the displayable Help list?
* [x] Have you updated any necessary documentation?
