### PR TITLE
New event for slack creation2

### DIFF
--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -185,7 +185,7 @@ export const configuration: any = {
         ingester("PackageConfigurationRequestedEvent"),
         ingester("ConfigServerRequestedEvent"),
         ingester("BroadcastMessageAllChannelsEvent"),
-        ingester("TeamSlackChannelCreatedEvent"),
+        ingester("TeamSetupCompletedEvent"),
     ],
     apiKey,
     http,

--- a/src/gluon/commands/team/LinkExistingTeamSlackChannel.ts
+++ b/src/gluon/commands/team/LinkExistingTeamSlackChannel.ts
@@ -8,6 +8,7 @@ import {
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TeamSlackChannelService} from "../../services/team/TeamSlackChannelService";
+import {QMMemberBase} from "../../util/member/Members";
 import {QMParamValidation} from "../../util/QMParamValidation";
 import {
     GluonTeamNameParam,
@@ -47,7 +48,8 @@ export class LinkExistingTeamSlackChannel extends RecursiveParameterRequestComma
 
     protected async runCommand(ctx: HandlerContext) {
         try {
-            const result = await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.newTeamChannel, false);
+            const member: QMMemberBase = await this.gluonService.members.gluonMemberFromScreenName(this.screenName);
+            const result = await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.newTeamChannel, member.memberId, false);
             this.succeedCommand();
             return result;
         } catch (error) {

--- a/src/gluon/commands/team/NewSlackChannel.ts
+++ b/src/gluon/commands/team/NewSlackChannel.ts
@@ -9,7 +9,9 @@ import {
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
 import * as _ from "lodash";
+import {GluonService} from "../../services/gluon/GluonService";
 import {TeamSlackChannelService} from "../../services/team/TeamSlackChannelService";
+import {QMMemberBase} from "../../util/member/Members";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
 import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
@@ -33,14 +35,16 @@ export class NewTeamSlackChannel extends BaseQMComand implements HandleCommand {
     })
     public newTeamChannel: string;
 
-    constructor(private teamSlackChannelService = new TeamSlackChannelService()) {
+    constructor(public gluonService = new GluonService(),
+                private teamSlackChannelService = new TeamSlackChannelService()) {
         super();
     }
 
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             this.newTeamChannel = _.isEmpty(this.newTeamChannel) ? this.teamName : this.newTeamChannel;
-            const result = await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.newTeamChannel, true);
+            const member: QMMemberBase = await this.gluonService.members.gluonMemberFromScreenName(this.screenName);
+            const result = await this.teamSlackChannelService.linkSlackChannelToGluonTeam(ctx, this.teamName, this.teamId, this.newTeamChannel, member.memberId, true);
             this.succeedCommand();
             return result;
         } catch (error) {

--- a/src/gluon/services/gluon/TeamService.ts
+++ b/src/gluon/services/gluon/TeamService.ts
@@ -114,9 +114,9 @@ export class TeamService {
         });
     }
 
-    public async addSlackDetailsToTeam(teamId: string, actionedByMemberId,  slackDetails: any): Promise<any> {
+    public async addSlackDetailsToTeam(teamId: string,  slackUpdateDetails: any): Promise<any> {
         logger.debug(`Trying to update team slack details. teamId: ${teamId}`);
-        return await this.axiosInstance.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}/members/${actionedByMemberId}`, slackDetails);
+        return await this.axiosInstance.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`, slackUpdateDetails);
     }
 
     public async addMemberToTeam(teamId: string, memberDetails: any): Promise<any> {

--- a/src/gluon/services/gluon/TeamService.ts
+++ b/src/gluon/services/gluon/TeamService.ts
@@ -114,9 +114,9 @@ export class TeamService {
         });
     }
 
-    public async addSlackDetailsToTeam(teamId: string, slackDetails: any): Promise<any> {
+    public async addSlackDetailsToTeam(teamId: string, actionedByMemberId,  slackDetails: any): Promise<any> {
         logger.debug(`Trying to update team slack details. teamId: ${teamId}`);
-        return await this.axiosInstance.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`, slackDetails);
+        return await this.axiosInstance.put(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}/members/${actionedByMemberId}`, slackDetails);
     }
 
     public async addMemberToTeam(teamId: string, memberDetails: any): Promise<any> {

--- a/src/gluon/services/team/TeamSlackChannelService.ts
+++ b/src/gluon/services/team/TeamSlackChannelService.ts
@@ -20,11 +20,12 @@ export class TeamSlackChannelService {
                                              gluonTeamName: string,
                                              slackTeamId: string,
                                              slackChannelName: string,
+                                             memberId: string,
                                              isNewChannel: boolean): Promise<any> {
 
         const team = await this.getGluonTeam(gluonTeamName);
 
-        await this.addSlackDetailsToGluonTeam(team.teamId, slackChannelName, isNewChannel);
+        await this.addSlackDetailsToGluonTeam(team.teamId, slackChannelName, memberId, isNewChannel);
 
         const channel = await this.createTeamSlackChannel(ctx, slackTeamId, slackChannelName);
 
@@ -47,6 +48,7 @@ export class TeamSlackChannelService {
 
     public async addSlackDetailsToGluonTeam(gluonTeamId: string,
                                             slackChannelName: string,
+                                            memberId,
                                             isNewChannel: boolean) {
         let finalisedSlackChannelName: string = slackChannelName;
         if (isNewChannel) {
@@ -55,7 +57,7 @@ export class TeamSlackChannelService {
 
         logger.info(`Updating team channel [${finalisedSlackChannelName}]: ${gluonTeamId}`);
 
-        const result = await this.gluonService.teams.addSlackDetailsToTeam(gluonTeamId, {
+        const result = await this.gluonService.teams.addSlackDetailsToTeam(gluonTeamId, memberId, {
             slack: {
                 teamChannel: finalisedSlackChannelName,
             },

--- a/src/gluon/services/team/TeamSlackChannelService.ts
+++ b/src/gluon/services/team/TeamSlackChannelService.ts
@@ -48,7 +48,7 @@ export class TeamSlackChannelService {
 
     public async addSlackDetailsToGluonTeam(gluonTeamId: string,
                                             slackChannelName: string,
-                                            memberId,
+                                            memberId: string,
                                             isNewChannel: boolean) {
         let finalisedSlackChannelName: string = slackChannelName;
         if (isNewChannel) {

--- a/src/gluon/services/team/TeamSlackChannelService.ts
+++ b/src/gluon/services/team/TeamSlackChannelService.ts
@@ -57,7 +57,8 @@ export class TeamSlackChannelService {
 
         logger.info(`Updating team channel [${finalisedSlackChannelName}]: ${gluonTeamId}`);
 
-        const result = await this.gluonService.teams.addSlackDetailsToTeam(gluonTeamId, memberId, {
+        const result = await this.gluonService.teams.addSlackDetailsToTeam(gluonTeamId, {
+            createdBy: memberId,
             slack: {
                 teamChannel: finalisedSlackChannelName,
             },

--- a/src/graphql/ingester/TeamSetupCompletedEvent.graphql
+++ b/src/graphql/ingester/TeamSetupCompletedEvent.graphql
@@ -1,0 +1,4 @@
+type TeamSetupCompletedEvent @rootType {
+  team: GluonTeam
+  createdBy: ActionedBy
+}

--- a/src/graphql/ingester/TeamSlackChannelCreatedEvent.graphql
+++ b/src/graphql/ingester/TeamSlackChannelCreatedEvent.graphql
@@ -1,4 +1,0 @@
-type TeamSlackChannelCreatedEvent @rootType {
-  team: GluonTeam
-  createdBy: ActionedBy
-}

--- a/test/gluon/services/team/TeamSlackChannelServiceTest.ts
+++ b/test/gluon/services/team/TeamSlackChannelServiceTest.ts
@@ -45,7 +45,7 @@ describe("TeamSlackChannelService getGluonTeam", () => {
 describe("TeamSlackChannelService addSlackDetailsToGluonTeam", () => {
     it("should fail to add slack details", async () => {
         const mockedTeamService = mock(TeamService);
-        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", "ActionedByMemberId1", anything())).thenResolve({status: 400});
+        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", anything())).thenResolve({status: 400});
         const gluonService = new GluonService(undefined, instance(mockedTeamService));
         const service = new TeamSlackChannelService(gluonService);
 
@@ -62,7 +62,7 @@ describe("TeamSlackChannelService addSlackDetailsToGluonTeam", () => {
 
     it("should succeed and add slack details", async () => {
         const mockedTeamService = mock(TeamService);
-        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", "ActionedByMemberId1", anything())).thenResolve({status: 200});
+        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", anything())).thenResolve({status: 200});
         const gluonService = new GluonService(undefined, instance(mockedTeamService));
         const service = new TeamSlackChannelService(gluonService);
 

--- a/test/gluon/services/team/TeamSlackChannelServiceTest.ts
+++ b/test/gluon/services/team/TeamSlackChannelServiceTest.ts
@@ -45,13 +45,13 @@ describe("TeamSlackChannelService getGluonTeam", () => {
 describe("TeamSlackChannelService addSlackDetailsToGluonTeam", () => {
     it("should fail to add slack details", async () => {
         const mockedTeamService = mock(TeamService);
-        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", anything())).thenResolve({status: 400});
+        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", "ActionedByMemberId1", anything())).thenResolve({status: 400});
         const gluonService = new GluonService(undefined, instance(mockedTeamService));
         const service = new TeamSlackChannelService(gluonService);
 
         let thrownError = null;
         try {
-            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", true);
+            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", "MemberId", true);
         } catch (error) {
             thrownError = error;
         }
@@ -62,13 +62,13 @@ describe("TeamSlackChannelService addSlackDetailsToGluonTeam", () => {
 
     it("should succeed and add slack details", async () => {
         const mockedTeamService = mock(TeamService);
-        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", anything())).thenResolve({status: 200});
+        when(mockedTeamService.addSlackDetailsToTeam("Team1Id", "ActionedByMemberId1", anything())).thenResolve({status: 200});
         const gluonService = new GluonService(undefined, instance(mockedTeamService));
         const service = new TeamSlackChannelService(gluonService);
 
         let thrownError = false;
         try {
-            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", true);
+            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", "MemberId", true);
         } catch (error) {
             thrownError = true;
         }

--- a/test/gluon/services/team/TeamSlackChannelServiceTest.ts
+++ b/test/gluon/services/team/TeamSlackChannelServiceTest.ts
@@ -51,7 +51,7 @@ describe("TeamSlackChannelService addSlackDetailsToGluonTeam", () => {
 
         let thrownError = null;
         try {
-            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", "MemberId", true);
+            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", "ActionedByMemberId1", true);
         } catch (error) {
             thrownError = error;
         }
@@ -68,7 +68,7 @@ describe("TeamSlackChannelService addSlackDetailsToGluonTeam", () => {
 
         let thrownError = false;
         try {
-            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", "MemberId", true);
+            await service.addSlackDetailsToGluonTeam("Team1Id", "channelName", "ActionedByMemberId1", true);
         } catch (error) {
             thrownError = true;
         }


### PR DESCRIPTION
### Description
to give gluon context of the user who create the team the memberId of the actioning user is added to the api call for creating the team slack channel.

### Essential Checks:

* [x] Have you added tests where necessary?
* [x] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [x] Have you added new commands to the displayable Help list?
* [x] Have you updated any necessary documentation?
