### PR TITLE
Testability refactoring investigation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ node_js:
   - 11.2.0
 script:
   - export NODE_ENV=test
-  - npm install codecov -g
   - npm run build
-after_success:
   - npm run sendCodeCoverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 11.2.0
 script:
   - export NODE_ENV=test
+  - npm install codecov -g
   - npm run build
-  - npm run tscSourceMap
+after_success:
   - npm run sendCodeCoverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - 11.2.0
 script:
   - export NODE_ENV=test
-  - npm run tscSourceMap
   - npm run build
+  - npm run tscSourceMap
   - npm run sendCodeCoverage

--- a/config/test.json
+++ b/config/test.json
@@ -113,6 +113,6 @@
     "workers": 1
   },
   "secondarySlackChannels": [
-    "sub-community"
+    "sub-discussion"
   ]
 }

--- a/config/test.json
+++ b/config/test.json
@@ -9,7 +9,7 @@
           "usernameCase": "lower",
           "internalDockerRegistryUrl": "123.123.0.0:5000",
           "externalDockerRegistryUrl": "registry.a.com",
-          "masterUrl": "https://000.000.00.0:8443",
+          "masterUrl": "https://non.prod:8443",
           "auth": {
             "token": "6kbO2PM3SbH9XrjQ3tw8crWq2_lduOnp-_tvq_VNy0c"
           },
@@ -63,6 +63,12 @@
       "sshPort": 30999,
       "cicdPrivateKeyPath": "/path/to/key",
       "cicdKey": "ssh-rsa somesecret"
+    },
+    "nexus": {
+      "baseUrl": "https://nexus.subatomic.local"
+    },
+    "maven": {
+      "settingsPath": "config/test.json"
     },
     "docs": {
       "baseUrl": "http://localhost:8080"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2561,6 +2561,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -3169,6 +3175,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3208,6 +3228,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "child-process-promise": {
       "version": "2.2.1",
@@ -3994,6 +4020,15 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -6042,6 +6077,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -9018,6 +9059,34 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
+    },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "node-bitmap": {
       "version": "0.0.1",
@@ -13391,6 +13460,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pause": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
@@ -13708,6 +13783,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
       "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg=="
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "proper-lockfile": {
       "version": "2.0.1",
@@ -15520,6 +15601,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/absa-subatomic/quantum-mechanic/issues"
   },
   "dependencies": {
+    "@absa-subatomic/openshift-api": "0.0.3",
     "@atomist/automation-client": "1.4.0",
     "@atomist/cli": "^1.4.0",
     "@atomist/sdm-pack-lifecycle": "^0.1.0",
@@ -44,6 +45,7 @@
     "form-data": "^2.3.3",
     "mocha": "^6.1.4",
     "mockttp": "^0.15.0",
+    "nock": "^10.0.6",
     "nodemon": "^1.19.1",
     "npm-run-all": "^4.1.3",
     "nyc": "^14.1.0",
@@ -85,7 +87,7 @@
     "lint:fix": "npm run lint -- --fix",
     "sendCodeCoverage": "nyc report --reporter=json && codecov -f coverage/*.json",
     "start": "atomist start --no-install --no-compile",
-    "test": "nyc mocha --require espower-typescript/guess \"test/**/*.ts\"",
+    "test": "NODE_ENV=test nyc mocha --require espower-typescript/guess \"test/**/*.ts\"",
     "test:one": "mocha --require espower-typescript/guess \"test/**/${TEST:-*.ts}\"",
     "typedoc": "typedoc --mode modules --excludeExternals --out build/typedoc src",
     "tscSourceMap": "tsc test/**/*.ts --module commonjs --sourcemap --lib es2015,dom,esnext.asynciterable"

--- a/src/config/QMConfig.ts
+++ b/src/config/QMConfig.ts
@@ -55,20 +55,24 @@ export class QMConfig {
 
     private static getConfigFile() {
         let configFile = "";
-        logger.info(`Searching folder: config/`);
-        fs.readdirSync(`config/`).forEach(file => {
-            logger.info(`Found file: ${file}`);
-            if (file.endsWith("local.json")) {
-                configFile = file;
-            } else if (file.endsWith("config.json") && configFile !== "local.json") {
-                configFile = file;
-            } else if (file.endsWith(".json") && configFile === "") {
-                configFile = file;
+        if (process.env.NODE_ENV === "test") {
+            configFile = "test.json";
+        } else {
+            logger.info(`Searching folder: config/`);
+            fs.readdirSync(`config/`).forEach(file => {
+                logger.info(`Found file: ${file}`);
+                if (file.endsWith("local.json")) {
+                    configFile = file;
+                } else if (file.endsWith("config.json") && configFile !== "local.json") {
+                    configFile = file;
+                } else if (file.endsWith(".json") && configFile === "") {
+                    configFile = file;
+                }
+            });
+            if (configFile === "") {
+                logger.error("Failed to read config file in config/ directory. Exiting.");
+                process.exit(1);
             }
-        });
-        if (configFile === "") {
-            logger.error("Failed to read config file in config/ directory. Exiting.");
-            process.exit(1);
         }
         logger.info(`Using config file: ${configFile}`);
         return `config/${configFile}`;

--- a/src/context/QMContext.ts
+++ b/src/context/QMContext.ts
@@ -1,0 +1,30 @@
+import {
+    addressEvent,
+    HandlerContext,
+    HandlerResult,
+} from "@atomist/automation-client";
+import {AtomistQMGraphClient, QMGraphClient} from "./QMGraphClient";
+import {AtomistQMMessageClient, QMMessageClient} from "./QMMessageClient";
+
+export interface QMContext {
+    messageClient: QMMessageClient;
+
+    graphClient: QMGraphClient;
+
+    raiseEvent(eventData: any, eventName: string): Promise<HandlerResult>;
+}
+
+export class AtomistQMContext implements QMContext {
+
+    public graphClient: QMGraphClient;
+    public messageClient: QMMessageClient;
+
+    constructor(private ctx: HandlerContext) {
+        this.graphClient = new AtomistQMGraphClient(ctx);
+        this.messageClient = new AtomistQMMessageClient(ctx);
+    }
+
+    public async raiseEvent(eventData: any, eventName: string): Promise<HandlerResult> {
+        return this.ctx.messageClient.send(eventData, addressEvent(eventName));
+    }
+}

--- a/src/context/QMContext.ts
+++ b/src/context/QMContext.ts
@@ -7,6 +7,8 @@ import {AtomistQMGraphClient, QMGraphClient} from "./QMGraphClient";
 import {AtomistQMMessageClient, QMMessageClient} from "./QMMessageClient";
 
 export interface QMContext {
+    descriminator: "QMContext";
+
     messageClient: QMMessageClient;
 
     graphClient: QMGraphClient;
@@ -16,6 +18,7 @@ export interface QMContext {
 
 export class AtomistQMContext implements QMContext {
 
+    public descriminator: "QMContext";
     public graphClient: QMGraphClient;
     public messageClient: QMMessageClient;
 
@@ -27,4 +30,8 @@ export class AtomistQMContext implements QMContext {
     public async raiseEvent(eventData: any, eventName: string): Promise<HandlerResult> {
         return this.ctx.messageClient.send(eventData, addressEvent(eventName));
     }
+}
+
+export function isQMContext(ctx: any): ctx is QMContext {
+    return ctx.descriminator === "QMContext";
 }

--- a/src/context/QMGraphClient.ts
+++ b/src/context/QMGraphClient.ts
@@ -1,0 +1,87 @@
+import {HandlerContext, logger} from "@atomist/automation-client";
+import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/lib/handlers/command/slack/AssociateRepo";
+import * as graphql from "../typings/types";
+
+export interface QMGraphClient {
+
+    slackScreenNameFromSlackUserId(slackUserId: string): Promise<string>;
+
+    slackChannelIdFromChannelName(channelName: string): Promise<string>;
+
+    kickUserFromSlackChannel(slackTeamId: string, slackChannelId: string, slackUserId: string): Promise<string>;
+
+    inviteUserToSlackChannel(slackTeamId: string, slackChannelId: string, slackUserId: string): Promise<any>;
+}
+
+export class AtomistQMGraphClient implements QMGraphClient {
+
+    constructor(private ctx: HandlerContext) {
+    }
+
+    public async inviteUserToSlackChannel(slackTeamId: string, slackChannelId: string, slackUserId: string): Promise<any> {
+        return await inviteUserToSlackChannel(this.ctx, slackTeamId, slackChannelId, slackUserId);
+    }
+
+    public async kickUserFromSlackChannel(slackTeamId: string, slackChannelId: string, slackUserId: string): Promise<string> {
+        const KickUserFromSlackChannelMutation = `mutation kickUserFromSlackChannel(
+    $teamId: String!
+    $channelId: String!
+    $userId: String!
+  ) {
+    kickUserFromSlackChannel(
+      chatTeamId: $teamId
+      channelId: $channelId
+      userId: $userId
+    ) {
+      id
+    }
+  }
+  `;
+
+        return await this.ctx.graphClient.mutate<any, any>({
+            mutation: KickUserFromSlackChannelMutation,
+            variables: {
+                teamId: slackTeamId,
+                channelId: slackChannelId,
+                userId: slackUserId,
+            },
+        });
+    }
+
+    public async slackChannelIdFromChannelName(channelName: string): Promise<string> {
+        try {
+            const result = await this.ctx.graphClient.query<graphql.ChatChannel.Query, graphql.ChatChannel.Variables>({
+                name: "ChatChannel",
+                variables: {name: channelName},
+            });
+
+            if (result) {
+                if (result.ChatChannel && result.ChatChannel.length > 0) {
+                    return result.ChatChannel[0].channelId;
+                }
+            }
+        } catch (error) {
+            logger.error("Error occurred running GraphQL query: %s", error);
+        }
+        return null;
+    }
+
+    public async slackScreenNameFromSlackUserId(slackUserId: string): Promise<string> {
+        try {
+            const result = await this.ctx.graphClient.query<graphql.ChatId.Query, graphql.ChatId.Variables>({
+                name: "ChatId",
+                variables: {userId: slackUserId},
+            });
+
+            if (result) {
+                if (result.ChatId && result.ChatId.length > 0) {
+                    return result.ChatId[0].screenName;
+                }
+            }
+        } catch (error) {
+            logger.error("Error occurred running GraphQL query: %s", error);
+        }
+        return null;
+    }
+
+}

--- a/src/context/QMGraphClient.ts
+++ b/src/context/QMGraphClient.ts
@@ -1,5 +1,5 @@
 import {HandlerContext, logger} from "@atomist/automation-client";
-import {inviteUserToSlackChannel} from "@atomist/lifecycle-automation/lib/handlers/command/slack/AssociateRepo";
+import {inviteUserToSlackChannel} from "@atomist/sdm-pack-lifecycle/lib/handlers/command/slack/AssociateRepo";
 import * as graphql from "../typings/types";
 
 export interface QMGraphClient {

--- a/src/context/QMMessageClient.ts
+++ b/src/context/QMMessageClient.ts
@@ -1,0 +1,102 @@
+import {
+    addressSlackChannelsFromContext,
+    addressSlackUsersFromContext,
+    HandlerContext,
+    HandlerResult,
+    MessageOptions,
+} from "@atomist/automation-client";
+import {SlackMessage} from "@atomist/slack-messages";
+
+export interface QMMessageClient {
+    channelMessageClient: ChannelMessageClient;
+    responderMessageClient: SimpleQMMessageClient;
+    userMessageClient: UserMessageClient;
+}
+
+export class AtomistQMMessageClient implements QMMessageClient {
+    public channelMessageClient: ChannelMessageClient;
+    public responderMessageClient: ResponderMessageClient;
+    public userMessageClient: UserMessageClient;
+
+    constructor(ctx: HandlerContext) {
+        this.channelMessageClient = new ChannelMessageClient(ctx);
+        this.responderMessageClient = new ResponderMessageClient(ctx);
+        this.userMessageClient = new UserMessageClient(ctx);
+    }
+}
+
+export interface SimpleQMMessageClient {
+    send(message: (string | SlackMessage), options?: MessageOptions): Promise<HandlerResult>;
+}
+
+export class ResponderMessageClient implements SimpleQMMessageClient {
+    private ctx: HandlerContext;
+
+    constructor(ctx: HandlerContext) {
+        this.ctx = ctx;
+    }
+
+    public async send(message: (string | SlackMessage), options?: MessageOptions): Promise<HandlerResult> {
+        return await this.ctx.messageClient.respond(message, options);
+    }
+}
+
+export class UserMessageClient implements SimpleQMMessageClient {
+    private readonly ctx: HandlerContext;
+    private users: string[];
+
+    constructor(ctx: HandlerContext) {
+        this.ctx = ctx;
+        this.users = [];
+    }
+
+    public addDestination(user: string) {
+        this.users.push(user);
+        return this;
+    }
+
+    public clearDestinations() {
+        this.users = [];
+        return this;
+    }
+
+    public async send(message: (string | SlackMessage), options?: MessageOptions): Promise<HandlerResult> {
+        const slackDestination = await addressSlackUsersFromContext(this.ctx, ...this.users);
+        return await this.ctx.messageClient.send(message, slackDestination, options);
+    }
+
+    public async sendToUsers(message: (string | SlackMessage), users: string[], options?: MessageOptions) {
+        const slackDestination = await addressSlackUsersFromContext(this.ctx, ...users);
+        return await this.ctx.messageClient.send(message, slackDestination, options);
+    }
+}
+
+export class ChannelMessageClient implements SimpleQMMessageClient {
+    private readonly ctx: HandlerContext;
+    private channels: string[];
+
+    constructor(ctx: HandlerContext) {
+        this.ctx = ctx;
+        this.channels = [];
+    }
+
+    public addDestination(channel: string) {
+        this.channels.push(channel);
+        return this;
+    }
+
+    public clearDestinations() {
+        this.channels = [];
+        return this;
+    }
+
+    public async send(message: (string | SlackMessage), options?: MessageOptions): Promise<HandlerResult> {
+        const slackDestination = await addressSlackChannelsFromContext(this.ctx, ...this.channels);
+        return await this.ctx.messageClient.send(message, slackDestination, options);
+    }
+
+    public async sendToChannels(message: (string | SlackMessage), channels: string[], options?: MessageOptions) {
+        const slackDestination = await addressSlackChannelsFromContext(this.ctx, ...channels);
+        return await this.ctx.messageClient.send(message, slackDestination, options);
+    }
+}

--- a/src/context/QMMessageClient.ts
+++ b/src/context/QMMessageClient.ts
@@ -14,9 +14,9 @@ export interface QMMessageClient {
 
     createUserMessageClient(): DirectedQMMessageClient;
 
-    sendToUsers(message: (string | SlackMessage), users: string[], options?: MessageOptions): Promise<HandlerResult>;
+    sendToUsers(message: (string | SlackMessage), users: string | string[], options?: MessageOptions): Promise<HandlerResult>;
 
-    sendToChannels(message: (string | SlackMessage), channels: string[], options?: MessageOptions): Promise<HandlerResult>;
+    sendToChannels(message: (string | SlackMessage), channels: string | string[], options?: MessageOptions): Promise<HandlerResult>;
 
     respond(message: (string | SlackMessage), options?: MessageOptions): Promise<HandlerResult>;
 }
@@ -42,13 +42,21 @@ export class AtomistQMMessageClient implements QMMessageClient {
         return await this.ctx.messageClient.respond(message, options);
     }
 
-    public async sendToChannels(message: string | SlackMessage, channels: string[], options?: MessageOptions) {
-        const slackDestination = await addressSlackChannelsFromContext(this.ctx, ...channels);
+    public async sendToChannels(message: string | SlackMessage, channels: string | string[], options?: MessageOptions) {
+        let destinations = channels;
+        if (typeof channels === "string") {
+            destinations = [channels];
+        }
+        const slackDestination = await addressSlackChannelsFromContext(this.ctx, ...destinations);
         return await this.ctx.messageClient.send(message, slackDestination, options);
     }
 
-    public async sendToUsers(message: string | SlackMessage, users: string[], options?: MessageOptions) {
-        const slackDestination = await addressSlackUsersFromContext(this.ctx, ...users);
+    public async sendToUsers(message: string | SlackMessage, users: string | string[], options?: MessageOptions) {
+        let destinations = users;
+        if (typeof users === "string") {
+            destinations = [users];
+        }
+        const slackDestination = await addressSlackUsersFromContext(this.ctx, ...destinations);
         return await this.ctx.messageClient.send(message, slackDestination, options);
     }
 }

--- a/src/gluon/commands/bitbucket/BitbucketProject.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProject.ts
@@ -11,6 +11,7 @@ import {
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {QMConfig} from "../../../config/QMConfig";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -25,8 +26,7 @@ import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/Recurs
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {
     atomistIntent,
     CommandIntent,

--- a/src/gluon/commands/bitbucket/BitbucketProjectAccessCommand.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProjectAccessCommand.ts
@@ -6,6 +6,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {TeamMembershipMessages} from "../../messages/member/TeamMembershipMessages";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -20,7 +21,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {isUserAMemberOfTheTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/bitbucket/BitbucketProjectRecommendedPracticesCommand.ts
+++ b/src/gluon/commands/bitbucket/BitbucketProjectRecommendedPracticesCommand.ts
@@ -5,6 +5,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {TeamMembershipMessages} from "../../messages/member/TeamMembershipMessages";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -19,7 +20,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {isUserAMemberOfTheTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/help/Help.ts
+++ b/src/gluon/commands/help/Help.ts
@@ -9,9 +9,10 @@ import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
 import {buttonForCommand} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import uuid = require("uuid");
 import {QMConfig} from "../../../config/QMConfig";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {QMColours} from "../../util/QMColour";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 import {HelpCategory} from "./HelpCategory";
 

--- a/src/gluon/commands/jenkins/JenkinsBuild.ts
+++ b/src/gluon/commands/jenkins/JenkinsBuild.ts
@@ -8,6 +8,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {QMConfig} from "../../../config/QMConfig";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {JenkinsService} from "../../services/jenkins/JenkinsService";
@@ -26,8 +27,7 @@ import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/Recurs
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/jenkins/JenkinsCredentialsRecreate.ts
+++ b/src/gluon/commands/jenkins/JenkinsCredentialsRecreate.ts
@@ -5,6 +5,10 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {
+    ResponderMessageClient,
+} from "../../../context/QMMessageClient";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
@@ -16,10 +20,8 @@ import {
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {
-    ChannelMessageClient,
     handleQMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/jenkins/JenkinsProdCredentialsRecreate.ts
+++ b/src/gluon/commands/jenkins/JenkinsProdCredentialsRecreate.ts
@@ -1,6 +1,10 @@
 import {HandlerContext, HandlerResult, Tags} from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    ResponderMessageClient,
+} from "../../../context/QMMessageClient";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
@@ -23,10 +27,8 @@ import {
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {
-    ChannelMessageClient,
     handleQMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/member/OnboardMember.ts
+++ b/src/gluon/commands/member/OnboardMember.ts
@@ -91,7 +91,7 @@ export class OnboardMember extends BaseQMComand {
         const secondaryChannelsInvited = await this.inviteMembersToSecondarySlackChannels(ctx);
 
         const message = this.onboardMessages.presentTeamCreationAndApplicationOptions(this.firstName, secondaryChannelsInvited);
-        const result = await ctx.messageClient.responderMessageClient.send(message);
+        const result = await ctx.messageClient.respond(message);
 
         this.succeedCommand();
         return result;
@@ -107,7 +107,7 @@ export class OnboardMember extends BaseQMComand {
                 await this.onboardMemberService.inviteUserToSecondarySlackChannel(ctx, this.teamId, this.firstName, channel, this.userId, this.screenName);
                 secondaryChannelsInvited.push(channel);
             } catch (error) {
-                await this.handleError(ctx.messageClient.responderMessageClient, error);
+                await this.handleError(ctx.messageClient.createResponderMessageClient(), error);
             }
         }
 

--- a/src/gluon/commands/member/OnboardMember.ts
+++ b/src/gluon/commands/member/OnboardMember.ts
@@ -10,24 +10,27 @@ import {
     Parameter,
     Tags,
 } from "@atomist/automation-client/lib/decorators";
-import {addressSlackUsersFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {QMConfig} from "../../../config/QMConfig";
+import {AtomistQMContext, QMContext} from "../../../context/QMContext";
+import {
+    ResponderMessageClient,
+    SimpleQMMessageClient,
+} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {OnboardMemberMessages} from "../../messages/member/OnboardMemberMessages";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OnboardMemberService} from "../../services/member/OnboardMemberService";
 import {QMParamValidation} from "../../util/QMParamValidation";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {
-    handleQMError,
-    QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+import {handleQMError, QMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Onboard a new team member", atomistIntent(CommandIntent.OnboardMember))
 @Tags("subatomic", "slack", "member")
 export class OnboardMember extends BaseQMComand {
+    @MappedParameter(MappedParameters.SlackTeam)
+    public teamId: string;
+
     @MappedParameter(MappedParameters.SlackUser)
     public userId: string;
 
@@ -65,43 +68,46 @@ export class OnboardMember extends BaseQMComand {
     public async handle(ctx: HandlerContext): Promise<HandlerResult> {
         try {
             logger.info("Requesting new Gluon user");
-
-            await this.createGluonTeamMember(
-                {
-                    firstName: this.firstName,
-                    lastName: this.lastName,
-                    email: this.email,
-                    domainUsername: this.domainUsername,
-                    slack: {
-                        screenName: this.screenName,
-                        userId: this.userId,
-                    },
-                });
-
-            const secondaryChannelsInvited = await this.inviteMembersToSecondarySlackChannels(ctx);
-
-            const message = this.onboardMessages.presentTeamCreationAndApplicationOptions(this.firstName, secondaryChannelsInvited);
-            const destination = await addressSlackUsersFromContext(ctx, this.userId);
-            const result = await ctx.messageClient.send(message, destination);
-
-            this.succeedCommand();
-            return result;
+            return await this.handleQMCommand(new AtomistQMContext(ctx));
         } catch (error) {
             this.failCommand();
-            return await this.handleError(ctx, error);
+            return await this.handleError(new ResponderMessageClient(ctx), error);
         }
     }
 
-    private async inviteMembersToSecondarySlackChannels(ctx: HandlerContext): Promise<string[]> {
+    public async handleQMCommand(ctx: QMContext): Promise<HandlerResult> {
+        await this.createGluonTeamMember(
+            {
+                firstName: this.firstName,
+                lastName: this.lastName,
+                email: this.email,
+                domainUsername: this.domainUsername,
+                slack: {
+                    screenName: this.screenName,
+                    userId: this.userId,
+                },
+            });
+
+        const secondaryChannelsInvited = await this.inviteMembersToSecondarySlackChannels(ctx);
+
+        const message = this.onboardMessages.presentTeamCreationAndApplicationOptions(this.firstName, secondaryChannelsInvited);
+        const result = await ctx.messageClient.responderMessageClient.send(message);
+
+        this.succeedCommand();
+        return result;
+
+    }
+
+    private async inviteMembersToSecondarySlackChannels(ctx: QMContext): Promise<string[]> {
 
         const secondaryChannelsInvited: string[] = [];
 
         for (const channel of QMConfig.secondarySlackChannels) {
             try {
-                await this.onboardMemberService.inviteUserToSecondarySlackChannel(ctx, this.firstName, channel, this.userId, this.screenName);
+                await this.onboardMemberService.inviteUserToSecondarySlackChannel(ctx, this.teamId, this.firstName, channel, this.userId, this.screenName);
                 secondaryChannelsInvited.push(channel);
             } catch (error) {
-                await this.handleError(ctx, error);
+                await this.handleError(ctx.messageClient.responderMessageClient, error);
             }
         }
 
@@ -120,8 +126,7 @@ export class OnboardMember extends BaseQMComand {
         }
     }
 
-    private async handleError(ctx: HandlerContext, error) {
-        const messageClient = new ResponderMessageClient(ctx);
+    private async handleError(messageClient: SimpleQMMessageClient, error) {
         return await handleQMError(messageClient, error);
     }
 }

--- a/src/gluon/commands/packages/ConfigureApplicationJenkinsProd.ts
+++ b/src/gluon/commands/packages/ConfigureApplicationJenkinsProd.ts
@@ -6,6 +6,9 @@ import {
 import {CommandHandler, Tags} from "@atomist/automation-client/lib/decorators";
 import {SlackMessage} from "@atomist/slack-messages";
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    SimpleQMMessageClient} from "../../../context/QMMessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {buildJenkinsProdDeploymentJobTemplates} from "../../events/packages/package-configuration-request/JenkinsDeploymentJobTemplateBuilder";
 import {TeamMembershipMessages} from "../../messages/member/TeamMembershipMessages";
 import {QMApplication} from "../../services/gluon/ApplicationService";
@@ -34,9 +37,7 @@ import {
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {
     handleQMError,
-    QMMessageClient,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {QMTenant} from "../../util/shared/Tenants";
 import {isUserAMemberOfTheTeam, QMTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
@@ -125,7 +126,7 @@ export class ConfigureApplicationJenkinsProd extends RecursiveParameterRequestCo
         }
     }
 
-    private async sendPackageProvisionedMessage(messageClient: QMMessageClient, applicationName: string, projectName: string) {
+    private async sendPackageProvisionedMessage(messageClient: SimpleQMMessageClient, applicationName: string, projectName: string) {
 
         const returnableSuccessMessage = this.getSuccessMessage(applicationName, projectName);
 

--- a/src/gluon/commands/packages/ConfigureBasicPackage.ts
+++ b/src/gluon/commands/packages/ConfigureBasicPackage.ts
@@ -10,6 +10,12 @@ import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
 import _ = require("lodash");
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    SimpleQMMessageClient} from "../../../context/QMMessageClient";
+import {
+    ChannelMessageClient,
+    ResponderMessageClient,
+} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {
     ImageStreamDefinition,
@@ -33,11 +39,8 @@ import {
 import {RecursiveSetterResult} from "../../util/recursiveparam/RecursiveSetterResult";
 import {JsonLoader} from "../../util/resources/JsonLoader";
 import {
-    ChannelMessageClient,
     handleQMError,
-    QMMessageClient,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {createMenuAttachment} from "../../util/shared/GenericMenu";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 import {ConfigurePackage} from "./ConfigurePackage";
@@ -109,7 +112,7 @@ export class ConfigureBasicPackage extends RecursiveParameterRequestCommand
 
     protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
         try {
-            const messageClient: QMMessageClient = new ChannelMessageClient(ctx).addDestination(this.teamChannel);
+            const messageClient: SimpleQMMessageClient = new ChannelMessageClient(ctx).addDestination(this.teamChannel);
             const jsonLoader = new JsonLoader();
             const definition: PackageDefinition = jsonLoader.readTemplatizedFileContents(this.getPathFromDefinitionName(this.packageDefinition), QMConfig.publicConfig());
             const unprocessedPackageDefinition: PackageDefinition = jsonLoader.readFileContents(this.getPathFromDefinitionName(this.packageDefinition));

--- a/src/gluon/commands/packages/ConfigurePackage.ts
+++ b/src/gluon/commands/packages/ConfigurePackage.ts
@@ -5,6 +5,9 @@ import {
     success,
 } from "@atomist/automation-client";
 import {CommandHandler, Tags} from "@atomist/automation-client/lib/decorators";
+import {
+    SimpleQMMessageClient} from "../../../context/QMMessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {PackageConfigurationRequestedEvent} from "../../events/packages/package-configuration-request/PackageConfigurationRequestedEvent";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
@@ -33,9 +36,7 @@ import {
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {
     handleQMError,
-    QMMessageClient,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {GluonToEvent} from "../../util/transform/GluonToEvent";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
@@ -103,7 +104,7 @@ export class ConfigurePackage extends RecursiveParameterRequestCommand
     }
 
     protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
-        const messageClient: QMMessageClient = new ResponderMessageClient(ctx);
+        const messageClient: SimpleQMMessageClient = new ResponderMessageClient(ctx);
         try {
             await this.requestPackageConfiguration(ctx);
             this.succeedCommand();

--- a/src/gluon/commands/packages/CreateApplicationProd.ts
+++ b/src/gluon/commands/packages/CreateApplicationProd.ts
@@ -8,6 +8,12 @@ import {
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {v4 as uuid} from "uuid";
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    SimpleQMMessageClient} from "../../../context/QMMessageClient";
+import {
+    ChannelMessageClient,
+    ResponderMessageClient,
+} from "../../../context/QMMessageClient";
 import {ProdRequestMessages} from "../../messages/prod/ProdRequestMessages";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
@@ -37,11 +43,8 @@ import {
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
 import {
-    ChannelMessageClient,
     handleQMError,
-    QMMessageClient,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Create application in prod", atomistIntent(CommandIntent.CreateApplicationProd))
@@ -156,7 +159,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
         return message;
     }
 
-    private async getRequestConfirmation(qmMessageClient: QMMessageClient) {
+    private async getRequestConfirmation(qmMessageClient: SimpleQMMessageClient) {
         await qmMessageClient.send({
             text: "🚀 Finding available resources...",
         });
@@ -168,7 +171,7 @@ export class CreateApplicationProd extends RecursiveParameterRequestCommand
         return await qmMessageClient.send(message, {id: this.correlationId});
     }
 
-    private async findAndListResources(qmMessageClient: QMMessageClient) {
+    private async findAndListResources(qmMessageClient: SimpleQMMessageClient) {
 
         const project: QMProject = await this.gluonService.projects.gluonProjectFromProjectName(this.projectName);
 

--- a/src/gluon/commands/packages/LinkExistingApplication.ts
+++ b/src/gluon/commands/packages/LinkExistingApplication.ts
@@ -6,6 +6,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
 import {PackageCommandService} from "../../services/packages/PackageCommandService";
@@ -21,7 +22,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Link an existing application", atomistIntent(CommandIntent.LinkExistingApplication))

--- a/src/gluon/commands/packages/LinkExistingLibrary.ts
+++ b/src/gluon/commands/packages/LinkExistingLibrary.ts
@@ -6,6 +6,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
 import {PackageCommandService} from "../../services/packages/PackageCommandService";
@@ -21,7 +22,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Link an existing library", atomistIntent(CommandIntent.LinkExistingLibrary))

--- a/src/gluon/commands/packages/PatchBuildConfigBaseImage.ts
+++ b/src/gluon/commands/packages/PatchBuildConfigBaseImage.ts
@@ -1,6 +1,7 @@
 import {HandlerContext, HandlerResult, Tags} from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {QMConfig} from "../../../config/QMConfig";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
 import {PatchPackageBuildConfigImage} from "../../tasks/packages/PatchPackageBuildConfigImage";
@@ -22,7 +23,7 @@ import {
     ImageTagSetter,
 } from "../../util/recursiveparam/OpenshiftParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Patch the s2i image used to build a package", atomistIntent(CommandIntent.PatchBuildConfigBaseImage))

--- a/src/gluon/commands/project/AssociateTeam.ts
+++ b/src/gluon/commands/project/AssociateTeam.ts
@@ -6,6 +6,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import * as _ from "lodash";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {menuAttachmentForProjects} from "../../util/project/Project";
@@ -17,8 +18,7 @@ import {RecursiveSetterResult} from "../../util/recursiveparam/RecursiveSetterRe
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {menuAttachmentForTeams} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/project/CreateGenericProd.ts
+++ b/src/gluon/commands/project/CreateGenericProd.ts
@@ -8,6 +8,12 @@ import {
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {v4 as uuid} from "uuid";
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    SimpleQMMessageClient} from "../../../context/QMMessageClient";
+import {
+    ChannelMessageClient,
+    ResponderMessageClient,
+} from "../../../context/QMMessageClient";
 import {ProdRequestMessages} from "../../messages/prod/ProdRequestMessages";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
@@ -35,11 +41,8 @@ import {
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
 import {
-    ChannelMessageClient,
     handleQMError,
-    QMMessageClient,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Move openshift resources to prod", atomistIntent(CommandIntent.CreateGenericProd))
@@ -149,7 +152,7 @@ export class CreateGenericProd extends RecursiveParameterRequestCommand
         return message;
     }
 
-    private async getRequestConfirmation(qmMessageClient: QMMessageClient) {
+    private async getRequestConfirmation(qmMessageClient: SimpleQMMessageClient) {
         await qmMessageClient.send({
             text: "🚀 Finding available resources...",
         });
@@ -161,7 +164,7 @@ export class CreateGenericProd extends RecursiveParameterRequestCommand
         return await qmMessageClient.send(message, {id: this.correlationId});
     }
 
-    private async findAndListResources(qmMessageClient: QMMessageClient) {
+    private async findAndListResources(qmMessageClient: SimpleQMMessageClient) {
 
         const project: QMProject = await this.gluonService.projects.gluonProjectFromProjectName(this.projectName);
 

--- a/src/gluon/commands/project/CreateProject.ts
+++ b/src/gluon/commands/project/CreateProject.ts
@@ -5,6 +5,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {
@@ -17,8 +18,7 @@ import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/Recurs
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/project/CreateProjectJenkinsJob.ts
+++ b/src/gluon/commands/project/CreateProjectJenkinsJob.ts
@@ -7,6 +7,9 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {
+    SimpleQMMessageClient} from "../../../context/QMMessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {TeamMembershipMessages} from "../../messages/member/TeamMembershipMessages";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMMemberBase} from "../../util/member/Members";
@@ -20,9 +23,7 @@ import {
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {
     handleQMError,
-    QMMessageClient,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {isUserAMemberOfTheTeam, QMTeam} from "../../util/team/Teams";
 import {GluonToEvent} from "../../util/transform/GluonToEvent";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
@@ -53,7 +54,7 @@ export class CreateProjectJenkinsJob extends RecursiveParameterRequestCommand
     protected async runCommand(ctx: HandlerContext): Promise<HandlerResult> {
         logger.info("Requesting jenkins job creation...");
 
-        const messageClient: QMMessageClient = new ResponderMessageClient(ctx);
+        const messageClient: SimpleQMMessageClient = new ResponderMessageClient(ctx);
 
         try {
             await messageClient.send({

--- a/src/gluon/commands/project/CreateProjectProdEnvironments.ts
+++ b/src/gluon/commands/project/CreateProjectProdEnvironments.ts
@@ -7,6 +7,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMProject} from "../../util/project/Project";
 import {
@@ -18,7 +19,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Create the OpenShift production environments for a project", atomistIntent(CommandIntent.CreateProjectProdEnvironments))

--- a/src/gluon/commands/project/DefineNewProjectEnvironments.ts
+++ b/src/gluon/commands/project/DefineNewProjectEnvironments.ts
@@ -11,6 +11,7 @@ import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/sp
 import {inspect} from "util";
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {TeamMembershipMessages} from "../../messages/member/TeamMembershipMessages";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -25,8 +26,7 @@ import {BaseQMComand} from "../../util/shared/BaseQMCommand";
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 
 @CommandHandler("Defines the project associated deployment pipelines using the available default environments")
 @Tags("subatomic", "project")

--- a/src/gluon/commands/project/ProjectDetails.ts
+++ b/src/gluon/commands/project/ProjectDetails.ts
@@ -9,6 +9,7 @@ import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
 import {buttonForCommand} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {SlackMessage} from "@atomist/slack-messages";
 import {QMConfig} from "../../../config/QMConfig";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMColours} from "../../util/QMColour";
 import {
@@ -20,8 +21,7 @@ import {BaseQMComand} from "../../util/shared/BaseQMCommand";
 import {
     handleQMError,
     logErrorAndReturnSuccess,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("List projects belonging to a team", atomistIntent(CommandIntent.ListTeamProjects))

--- a/src/gluon/commands/project/ReRunProjectProdRequest.ts
+++ b/src/gluon/commands/project/ReRunProjectProdRequest.ts
@@ -9,9 +9,10 @@ import {
     addressEvent,
     addressSlackChannelsFromContext,
 } from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 
 @CommandHandler("Re-run a failed project production request")
 export class ReRunProjectProdRequest extends BaseQMComand {

--- a/src/gluon/commands/project/UpdateProjectProdRequest.ts
+++ b/src/gluon/commands/project/UpdateProjectProdRequest.ts
@@ -5,10 +5,11 @@ import {
     Parameter,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {ProjectProdRequestApprovalResponse} from "../../util/project/Project";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 
 @CommandHandler("Ignore a project prod request")
 export class UpdateProjectProdRequest extends BaseQMComand {

--- a/src/gluon/commands/project/request-project-environments/RequestProjectEnvironments.ts
+++ b/src/gluon/commands/project/request-project-environments/RequestProjectEnvironments.ts
@@ -9,6 +9,10 @@ import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import _ = require("lodash");
 import {inspect} from "util";
 import {QMConfig} from "../../../../config/QMConfig";
+import {
+    SimpleQMMessageClient,
+} from "../../../../context/QMMessageClient";
+import {ChannelMessageClient} from "../../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../../http/Http";
 import {TeamMembershipMessages} from "../../../messages/member/TeamMembershipMessages";
 import {GluonService} from "../../../services/gluon/GluonService";
@@ -22,11 +26,9 @@ import {
 } from "../../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {
-    ChannelMessageClient,
     handleQMError,
     QMError,
-    QMMessageClient,
-} from "../../../util/shared/Error";
+    } from "../../../util/shared/Error";
 import {DefinePipelineMessages} from "./DefinePipelineMessages";
 
 @CommandHandler("Create new OpenShift environments for a project", QMConfig.subatomic.commandPrefix + " request project environments")
@@ -60,7 +62,7 @@ export class RequestProjectEnvironments extends RecursiveParameterRequestCommand
 
         const project: QMProject = await this.gluonService.projects.gluonProjectFromProjectName(this.projectName);
 
-        const messageClient: QMMessageClient = new ChannelMessageClient(ctx).addDestination(project.owningTeam.slack.teamChannel);
+        const messageClient: SimpleQMMessageClient = new ChannelMessageClient(ctx).addDestination(project.owningTeam.slack.teamChannel);
 
         try {
             await messageClient.send({

--- a/src/gluon/commands/team/AddConfigServer.ts
+++ b/src/gluon/commands/team/AddConfigServer.ts
@@ -6,6 +6,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {ConfigServerRequestedEvent} from "../../events/team/ConfigServerRequested";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMMemberBase} from "../../util/member/Members";
@@ -16,7 +17,7 @@ import {
     GluonTeamOpenShiftCloudParam,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 import {GluonToEvent} from "../../util/transform/GluonToEvent";
 import {atomistIntent, CommandIntent} from "../CommandIntent";

--- a/src/gluon/commands/team/AddMemberToTeam.ts
+++ b/src/gluon/commands/team/AddMemberToTeam.ts
@@ -7,6 +7,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
@@ -17,7 +18,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Add a member to a team", atomistIntent(CommandIntent.AddMemberToTeam))

--- a/src/gluon/commands/team/AddOwnerToTeam.ts
+++ b/src/gluon/commands/team/AddOwnerToTeam.ts
@@ -7,6 +7,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
@@ -17,7 +18,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Add a member as an owner to a team", atomistIntent(CommandIntent.AddOwnerToTeam))

--- a/src/gluon/commands/team/CreateMembershipRequestToTeam.ts
+++ b/src/gluon/commands/team/CreateMembershipRequestToTeam.ts
@@ -6,6 +6,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {getScreenName, loadScreenNameByUserId} from "../../util/member/Members";
@@ -13,8 +14,7 @@ import {BaseQMComand} from "../../util/shared/BaseQMCommand";
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 
 @CommandHandler("Request membership to a team")
 export class CreateMembershipRequestToTeam extends BaseQMComand implements HandleCommand<HandlerResult> {

--- a/src/gluon/commands/team/CreateTeam.ts
+++ b/src/gluon/commands/team/CreateTeam.ts
@@ -7,6 +7,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMParamValidation} from "../../util/QMParamValidation";
@@ -18,8 +19,7 @@ import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/Recurs
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Create a new team", atomistIntent(CommandIntent.CreateTeam))

--- a/src/gluon/commands/team/DevOpsEnvironment.ts
+++ b/src/gluon/commands/team/DevOpsEnvironment.ts
@@ -5,7 +5,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
-import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {AtomistQMContext, QMContext} from "../../../context/QMContext";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {
@@ -30,7 +30,7 @@ export class NewDevOpsEnvironment extends RecursiveParameterRequestCommand
         super();
     }
 
-    protected runCommand(ctx: HandlerContext) {
+    public runQMCommand(ctx: QMContext) {
         return this.requestDevOpsEnvironment(
             ctx,
             this.screenName,
@@ -39,12 +39,16 @@ export class NewDevOpsEnvironment extends RecursiveParameterRequestCommand
         );
     }
 
-    private async requestDevOpsEnvironment(ctx: HandlerContext, screenName: string,
+    protected runCommand(ctx: HandlerContext) {
+        return this.runQMCommand(new AtomistQMContext(ctx));
+    }
+
+    private async requestDevOpsEnvironment(ctx: QMContext,
+                                           screenName: string,
                                            teamName: string,
                                            teamChannel: string): Promise<any> {
 
-        const destination = await addressSlackChannelsFromContext(ctx, teamChannel);
-        await ctx.messageClient.send(`Requesting DevOps environment for *${teamName}* team.`, destination);
+        await ctx.messageClient.sendToChannels(`Requesting DevOps environment for *${teamName}* team.`, teamChannel);
 
         const member = await this.gluonService.members.gluonMemberFromScreenName(screenName);
 

--- a/src/gluon/commands/team/JoinTeam.ts
+++ b/src/gluon/commands/team/JoinTeam.ts
@@ -8,6 +8,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {JoinTeamMessages} from "../../messages/team/JoinTeamMessages";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -15,8 +16,7 @@ import {BaseQMComand} from "../../util/shared/BaseQMCommand";
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Apply to join an existing team", atomistIntent(CommandIntent.JoinTeam))

--- a/src/gluon/commands/team/LinkExistingTeamSlackChannel.ts
+++ b/src/gluon/commands/team/LinkExistingTeamSlackChannel.ts
@@ -6,6 +6,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TeamSlackChannelService} from "../../services/team/TeamSlackChannelService";
 import {QMMemberBase} from "../../util/member/Members";
@@ -15,7 +16,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Link existing team channel", atomistIntent(CommandIntent.LinkExistingTeamSlackChannel))

--- a/src/gluon/commands/team/ListTeamMembers.ts
+++ b/src/gluon/commands/team/ListTeamMembers.ts
@@ -6,6 +6,7 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {SlackMessage} from "@atomist/slack-messages";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {Extensible} from "../../util/plugins/Extensible";
 import {QMColours} from "../../util/QMColour";
@@ -14,7 +15,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("List members of a team", atomistIntent(CommandIntent.ListTeamMembers))

--- a/src/gluon/commands/team/MigrateTeamCloud.ts
+++ b/src/gluon/commands/team/MigrateTeamCloud.ts
@@ -3,12 +3,14 @@ import {
     HandlerContext,
     HandlerResult,
     Parameter,
-    success,
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {SlackMessage} from "@atomist/slack-messages";
-import {v4 as uuid} from "uuid";
+import {
+    ChannelMessageClient,
+    ResponderMessageClient,
+} from "../../../context/QMMessageClient";
 import {DocumentationUrlBuilder} from "../../messages/documentation/DocumentationUrlBuilder";
 import {GluonService} from "../../services/gluon/GluonService";
 import {OCService} from "../../services/openshift/OCService";
@@ -25,11 +27,7 @@ import {
     RecursiveParameterRequestCommand,
 } from "../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
-import {
-    ChannelMessageClient,
-    handleQMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 

--- a/src/gluon/commands/team/NewOrExistingTeamSlackChannel.ts
+++ b/src/gluon/commands/team/NewOrExistingTeamSlackChannel.ts
@@ -5,9 +5,10 @@ import {
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {TeamSlackChannelMessages} from "../../messages/team/TeamSlackChannelMessages";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 
 @CommandHandler("Check whether to create a new team channel or use an existing channel")
 export class NewOrUseTeamSlackChannel extends BaseQMComand implements HandleCommand {

--- a/src/gluon/commands/team/NewSlackChannel.ts
+++ b/src/gluon/commands/team/NewSlackChannel.ts
@@ -9,11 +9,12 @@ import {
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleCommand} from "@atomist/automation-client/lib/HandleCommand";
 import * as _ from "lodash";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TeamSlackChannelService} from "../../services/team/TeamSlackChannelService";
 import {QMMemberBase} from "../../util/member/Members";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Create team channel", atomistIntent(CommandIntent.NewTeamSlackChannel))

--- a/src/gluon/commands/team/ReRunMigrateTeamCloud.ts
+++ b/src/gluon/commands/team/ReRunMigrateTeamCloud.ts
@@ -9,9 +9,10 @@ import {
     addressEvent,
     addressSlackChannelsFromContext,
 } from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {BaseQMComand} from "../../util/shared/BaseQMCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 
 @CommandHandler("Re-run a failed team cloud migration")
 export class ReRunMigrateTeamCloud extends BaseQMComand {

--- a/src/gluon/commands/team/RemoveMemberFromTeam.ts
+++ b/src/gluon/commands/team/RemoveMemberFromTeam.ts
@@ -7,6 +7,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {GluonService} from "../../services/gluon/GluonService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
 import {TaskRunner} from "../../tasks/TaskRunner";
@@ -17,7 +18,7 @@ import {
     GluonTeamNameSetter,
 } from "../../util/recursiveparam/GluonParameterSetters";
 import {RecursiveParameterRequestCommand} from "../../util/recursiveparam/RecursiveParameterRequestCommand";
-import {handleQMError, ResponderMessageClient} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {atomistIntent, CommandIntent} from "../CommandIntent";
 
 @CommandHandler("Remove a member from a team", atomistIntent(CommandIntent.RemoveMemberFromTeam))

--- a/src/gluon/events/bitbucket/BitbucketProjectAdded.ts
+++ b/src/gluon/events/bitbucket/BitbucketProjectAdded.ts
@@ -7,6 +7,7 @@ import {
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {buttonForCommand} from "@atomist/automation-client/lib/spi/message/MessageClient";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {BitbucketProjectRecommendedPracticesCommand} from "../../commands/bitbucket/BitbucketProjectRecommendedPracticesCommand";
 import {CommandIntent} from "../../commands/CommandIntent";
 import {AssociateTeam} from "../../commands/project/AssociateTeam";
@@ -20,7 +21,7 @@ import {TaskRunner} from "../../tasks/TaskRunner";
 import {QMProjectBase} from "../../util/project/Project";
 import {QMColours} from "../../util/QMColour";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 
 @EventHandler("Receive BitbucketProjectAddedEvent events", `
 subscription BitbucketProjectAddedEvent {

--- a/src/gluon/events/packages/ApplicationProdRequested.ts
+++ b/src/gluon/events/packages/ApplicationProdRequested.ts
@@ -8,6 +8,7 @@ import {
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {QMConfig} from "../../../config/QMConfig";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {QMApplicationProdRequest} from "../../services/gluon/ApplicationProdRequestService";
 import {QMApplication} from "../../services/gluon/ApplicationService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -25,7 +26,7 @@ import {
     QMProject,
 } from "../../util/project/Project";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTenant} from "../../util/shared/Tenants";
 import {QMTeam} from "../../util/team/Teams";
 import {buildJenkinsProdDeploymentJobTemplates} from "./package-configuration-request/JenkinsDeploymentJobTemplateBuilder";

--- a/src/gluon/events/packages/package-configuration-request/PackageConfigurationRequested.ts
+++ b/src/gluon/events/packages/package-configuration-request/PackageConfigurationRequested.ts
@@ -10,6 +10,10 @@ import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {SlackMessage} from "@atomist/slack-messages";
 import {QMConfig} from "../../../../config/QMConfig";
+import {
+    SimpleQMMessageClient,
+} from "../../../../context/QMMessageClient";
+import {ChannelMessageClient} from "../../../../context/QMMessageClient";
 import {CommandIntent} from "../../../commands/CommandIntent";
 import {KickOffJenkinsBuild} from "../../../commands/jenkins/JenkinsBuild";
 import {DocumentationUrlBuilder} from "../../../messages/documentation/DocumentationUrlBuilder";
@@ -31,11 +35,9 @@ import {QMProject} from "../../../util/project/Project";
 import {ParameterDisplayType} from "../../../util/recursiveparam/RecursiveParameterRequestCommand";
 import {BaseQMEvent} from "../../../util/shared/BaseQMEvent";
 import {
-    ChannelMessageClient,
     handleQMError,
     QMError,
-    QMMessageClient,
-} from "../../../util/shared/Error";
+    } from "../../../util/shared/Error";
 import {QMTenant} from "../../../util/shared/Tenants";
 import {isUserAMemberOfTheTeam, QMTeam} from "../../../util/team/Teams";
 import {buildJenkinsDeploymentJobTemplates} from "./JenkinsDeploymentJobTemplateBuilder";
@@ -86,7 +88,7 @@ export class PackageConfigurationRequested extends BaseQMEvent implements Handle
         logger.info(`Ingested PackageConfigurationRequested event: ${JSON.stringify(event.data)}`);
         const packageConfigurationRequestedEvent: PackageConfigurationRequestedEvent = event.data.PackageConfigurationRequestedEvent[0];
         const project: QMProject = await this.gluonService.projects.gluonProjectFromProjectName(packageConfigurationRequestedEvent.project.name);
-        const messageClient: QMMessageClient = new ChannelMessageClient(ctx).addDestination(project.owningTeam.slack.teamChannel);
+        const messageClient: SimpleQMMessageClient = new ChannelMessageClient(ctx).addDestination(project.owningTeam.slack.teamChannel);
         try {
 
             await this.configurePackage(ctx, messageClient, packageConfigurationRequestedEvent);
@@ -98,7 +100,7 @@ export class PackageConfigurationRequested extends BaseQMEvent implements Handle
         }
     }
 
-    private async configurePackage(ctx: HandlerContext, messageClient: QMMessageClient, packageConfigurationEvent: PackageConfigurationRequestedEvent): Promise<HandlerResult> {
+    private async configurePackage(ctx: HandlerContext, messageClient: SimpleQMMessageClient, packageConfigurationEvent: PackageConfigurationRequestedEvent): Promise<HandlerResult> {
         const project: QMProject = await this.gluonService.projects.gluonProjectFromProjectName(packageConfigurationEvent.project.name);
 
         const application: QMApplication = await this.gluonService.applications.gluonApplicationForNameAndProjectName(packageConfigurationEvent.application.name, project.name);
@@ -169,7 +171,7 @@ export class PackageConfigurationRequested extends BaseQMEvent implements Handle
 
     }
 
-    private async sendPackageProvisionedMessage(messageClient: QMMessageClient, applicationName: string, projectName: string, applicationType: ApplicationType) {
+    private async sendPackageProvisionedMessage(messageClient: SimpleQMMessageClient, applicationName: string, projectName: string, applicationType: ApplicationType) {
 
         const returnableSuccessMessage = this.getDefaultSuccessMessage(applicationName, projectName, applicationType);
 

--- a/src/gluon/events/project/GenericProdRequested.ts
+++ b/src/gluon/events/project/GenericProdRequested.ts
@@ -9,6 +9,7 @@ import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {QMConfig} from "../../../config/QMConfig";
 
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {ProdRequestMessages} from "../../messages/prod/ProdRequestMessages";
 import {QMGenericProdRequest} from "../../services/gluon/GenericProdRequestService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -24,7 +25,7 @@ import {
     QMProject,
 } from "../../util/project/Project";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTenant} from "../../util/shared/Tenants";
 import {QMTeam} from "../../util/team/Teams";
 

--- a/src/gluon/events/project/ProjectEnvironmentsRequested.ts
+++ b/src/gluon/events/project/ProjectEnvironmentsRequested.ts
@@ -8,6 +8,7 @@ import {
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {QMConfig} from "../../../config/QMConfig";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {ProjectMessages} from "../../messages/projects/ProjectMessages";
 import {GluonService} from "../../services/gluon/GluonService";
 import {ConfigureJenkinsForProject} from "../../tasks/project/ConfigureJenkinsForProject";
@@ -20,7 +21,7 @@ import {
     QMProject,
 } from "../../util/project/Project";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTeam} from "../../util/team/Teams";
 
 @EventHandler("Receive ProjectEnvironmentsRequestedEvent events", `

--- a/src/gluon/events/project/ProjectJenkinsJobRequested.ts
+++ b/src/gluon/events/project/ProjectJenkinsJobRequested.ts
@@ -9,6 +9,10 @@ import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {SlackMessage} from "@atomist/slack-messages";
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    SimpleQMMessageClient,
+} from "../../../context/QMMessageClient";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {CommandIntent} from "../../commands/CommandIntent";
 import {LinkExistingLibrary} from "../../commands/packages/LinkExistingLibrary";
 import {DocumentationUrlBuilder} from "../../messages/documentation/DocumentationUrlBuilder";
@@ -23,10 +27,8 @@ import {
 import {QMColours} from "../../util/QMColour";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
 import {
-    ChannelMessageClient,
     handleQMError,
-    QMMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {QMTenant} from "../../util/shared/Tenants";
 import {QMTeam} from "../../util/team/Teams";
 
@@ -98,7 +100,7 @@ export class ProjectJenkinsJobRequested extends BaseQMEvent implements HandleEve
         }
     }
 
-    private async sendPackageUsageMessage(qmMessageClient: QMMessageClient, projectName: string) {
+    private async sendPackageUsageMessage(qmMessageClient: SimpleQMMessageClient, projectName: string) {
         const msg: SlackMessage = {
             text: `
 Since you have a project Jenkins project folder ready, you can now add libraries to you project. Note that to add an application instead of a library, you need to have OpenShift environments created.`,

--- a/src/gluon/events/project/ProjectProductionEnvironmentsRequestClosed.ts
+++ b/src/gluon/events/project/ProjectProductionEnvironmentsRequestClosed.ts
@@ -11,6 +11,7 @@ import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {v4 as uuid} from "uuid";
 import {QMConfig} from "../../../config/QMConfig";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {ReRunProjectProdRequest} from "../../commands/project/ReRunProjectProdRequest";
 import {ProdRequestMessages} from "../../messages/prod/ProdRequestMessages";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -29,7 +30,7 @@ import {
 import {QMColours} from "../../util/QMColour";
 import {ApprovalEnum} from "../../util/shared/ApprovalEnum";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {getDevOpsEnvironmentDetailsProd} from "../../util/team/Teams";
 
 @EventHandler("Receive ProjectProductionEnvironmentsRequestClosedEvent events", `

--- a/src/gluon/events/project/ProjectProductionEnvironmentsRequested.ts
+++ b/src/gluon/events/project/ProjectProductionEnvironmentsRequested.ts
@@ -12,6 +12,7 @@ import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {SlackMessage} from "@atomist/slack-messages";
 import _ = require("lodash");
 import {v4 as uuid} from "uuid";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {UpdateProjectProdRequest} from "../../commands/project/UpdateProjectProdRequest";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMProjectProdRequest} from "../../services/gluon/ProjectProdRequestService";
@@ -22,7 +23,7 @@ import {
     QMProject,
 } from "../../util/project/Project";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 
 @EventHandler("Receive ProjectProductionEnvironmentsRequestedEvent events", `
 subscription ProjectProductionEnvironmentsRequestedEvent {

--- a/src/gluon/events/project/TeamAssociated.ts
+++ b/src/gluon/events/project/TeamAssociated.ts
@@ -7,8 +7,8 @@ import {
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import _ = require("lodash");
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient} from "../../util/shared/Error";
 
 @EventHandler("Receive TeamsLinkedToProject events", `
 subscription TeamsLinkedToProjectEvent {

--- a/src/gluon/events/team/BotJoinedChannel.ts
+++ b/src/gluon/events/team/BotJoinedChannel.ts
@@ -16,6 +16,7 @@ import {
 } from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {SlackMessage} from "@atomist/slack-messages";
 import _ = require("lodash");
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {OnboardMember} from "../../commands/member/OnboardMember";
 import {AddMemberToTeam} from "../../commands/team/AddMemberToTeam";
 import {NewDevOpsEnvironment} from "../../commands/team/DevOpsEnvironment";
@@ -23,7 +24,6 @@ import {DocumentationUrlBuilder} from "../../messages/documentation/Documentatio
 import {GluonService} from "../../services/gluon/GluonService";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
 import {
-    ChannelMessageClient,
     handleQMError,
     QMError,
 } from "../../util/shared/Error";

--- a/src/gluon/events/team/ConfigServerRequested.ts
+++ b/src/gluon/events/team/ConfigServerRequested.ts
@@ -7,6 +7,10 @@ import {
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {SlackMessage} from "@atomist/slack-messages";
+import {
+    SimpleQMMessageClient,
+} from "../../../context/QMMessageClient";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {CommandIntent} from "../../commands/CommandIntent";
 import {DocumentationUrlBuilder} from "../../messages/documentation/DocumentationUrlBuilder";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
@@ -14,10 +18,8 @@ import {TaskRunner} from "../../tasks/TaskRunner";
 import {CreateConfigServer} from "../../tasks/team/CreateConfigServer";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
 import {
-    ChannelMessageClient,
     handleQMError,
-    QMMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
 import {GluonTeamEvent} from "../../util/transform/types/event/GluonTeamEvent";
 import {MemberEvent} from "../../util/transform/types/event/MemberEvent";
@@ -53,7 +55,7 @@ export class ConfigServerRequested extends BaseQMEvent implements HandleEvent<an
         logger.info(`Ingested ConfigServerRequested event: ${JSON.stringify(event.data)}`);
         const configServerRequestedEvent: ConfigServerRequestedEvent = event.data.ConfigServerRequestedEvent[0];
 
-        const messageClient: QMMessageClient = new ChannelMessageClient(ctx).addDestination(configServerRequestedEvent.team.slackIdentity.teamChannel);
+        const messageClient: SimpleQMMessageClient = new ChannelMessageClient(ctx).addDestination(configServerRequestedEvent.team.slackIdentity.teamChannel);
 
         try {
             const taskListMessage = new TaskListMessage(`:rocket: Deploying config server into *${configServerRequestedEvent.team.name}* team DevOps...`, messageClient);
@@ -70,7 +72,7 @@ export class ConfigServerRequested extends BaseQMEvent implements HandleEvent<an
         }
     }
 
-    private async sendSuccessResponse(messageClient: QMMessageClient, gluonTeamName: string) {
+    private async sendSuccessResponse(messageClient: SimpleQMMessageClient, gluonTeamName: string) {
         const devOpsProjectId = getDevOpsEnvironmentDetails(gluonTeamName).openshiftProjectId;
         const slackMessage: SlackMessage = {
             text: `Your Subatomic Config Server has been added to your *${devOpsProjectId}* OpenShift project successfully`,

--- a/src/gluon/events/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/events/team/DevOpsEnvironmentRequested.ts
@@ -10,6 +10,7 @@ import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {addressEvent} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {timeout, TimeoutError} from "promise-timeout";
 import {QMConfig} from "../../../config/QMConfig";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {DevOpsMessages} from "../../messages/team/DevOpsMessages";
 import {OCService} from "../../services/openshift/OCService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
@@ -17,7 +18,7 @@ import {TaskRunner} from "../../tasks/TaskRunner";
 import {AddJenkinsToDevOpsEnvironment} from "../../tasks/team/AddJenkinsToDevOpsEnvironment";
 import {CreateTeamDevOpsEnvironment} from "../../tasks/team/CreateTeamDevOpsEnvironment";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {getDevOpsEnvironmentDetails, QMTeam} from "../../util/team/Teams";
 import {EventToGluon} from "../../util/transform/EventToGluon";
 

--- a/src/gluon/events/team/DevOpsEnvironmentRequested.ts
+++ b/src/gluon/events/team/DevOpsEnvironmentRequested.ts
@@ -1,5 +1,4 @@
 import {
-    addressSlackChannelsFromContext,
     EventFired,
     HandlerContext,
     HandlerResult,
@@ -7,10 +6,9 @@ import {
 } from "@atomist/automation-client";
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
-import {addressEvent} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {timeout, TimeoutError} from "promise-timeout";
 import {QMConfig} from "../../../config/QMConfig";
-import {ChannelMessageClient} from "../../../context/QMMessageClient";
+import {AtomistQMContext, QMContext} from "../../../context/QMContext";
 import {DevOpsMessages} from "../../messages/team/DevOpsMessages";
 import {OCService} from "../../services/openshift/OCService";
 import {TaskListMessage} from "../../tasks/TaskListMessage";
@@ -67,13 +65,14 @@ export class DevOpsEnvironmentRequested extends BaseQMEvent implements HandleEve
 
     public async handle(event: EventFired<any>, ctx: HandlerContext): Promise<HandlerResult> {
         logger.info(`Ingested DevOpsEnvironmentRequestedEvent event: ${JSON.stringify(event.data)}`);
+        return await this.handleQMEvent(event.data.DevOpsEnvironmentRequestedEvent[0], new AtomistQMContext(ctx));
+    }
 
-        const devOpsRequestedEvent = event.data.DevOpsEnvironmentRequestedEvent[0];
-
+    public async handleQMEvent(devOpsRequestedEvent: any, ctx: QMContext): Promise<HandlerResult> {
         try {
             const teamChannel = devOpsRequestedEvent.team.slackIdentity.teamChannel;
             const team: QMTeam = EventToGluon.gluonTeam(devOpsRequestedEvent.team);
-            const taskListMessage = new TaskListMessage(`🚀 Provisioning of DevOps environment for team *${devOpsRequestedEvent.team.name}* started:`, new ChannelMessageClient(ctx).addDestination(teamChannel));
+            const taskListMessage = new TaskListMessage(`🚀 Provisioning of DevOps environment for team *${devOpsRequestedEvent.team.name}* started:`, ctx.messageClient.createChannelMessageClient().addDestination(teamChannel));
             const taskRunner = new TaskRunner(taskListMessage);
             const openShiftCloud = EventToGluon.gluonTeam(devOpsRequestedEvent.team).openShiftCloud;
             taskRunner.addTask(
@@ -91,28 +90,22 @@ export class DevOpsEnvironmentRequested extends BaseQMEvent implements HandleEve
                 devOpsEnvironment: getDevOpsEnvironmentDetails(devOpsRequestedEvent.team.name),
             };
             this.succeedEvent();
-            return await ctx.messageClient.send(devopsEnvironmentProvisionedEvent, addressEvent("DevOpsEnvironmentProvisionedEvent"));
-
+            return await ctx.raiseEvent(devopsEnvironmentProvisionedEvent, "DevOpsEnvironmentProvisionedEvent");
         } catch (error) {
             this.failEvent();
-            return await this.handleError(ctx, error, devOpsRequestedEvent.team.slackIdentity.teamChannel);
+            return await handleQMError(ctx.messageClient.createChannelMessageClient().addDestination(devOpsRequestedEvent.team.slackIdentity.teamChannel), error);
         }
     }
 
-    private async sendDevOpsSuccessfullyProvisionedMessage(ctx: HandlerContext, team: QMTeam) {
+    private async sendDevOpsSuccessfullyProvisionedMessage(ctx: QMContext, team: QMTeam) {
 
         await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[team.openShiftCloud].openshiftNonProd);
 
         const jenkinsHost = await this.ocService.getJenkinsHost(getDevOpsEnvironmentDetails(team.name).openshiftProjectId);
 
-        const destination = await addressSlackChannelsFromContext(ctx, team.slack.teamChannel);
-        await ctx.messageClient.send(
+        await ctx.messageClient.sendToChannels(
             this.devopsMessages.jenkinsSuccessfullyProvisioned(jenkinsHost, team.name),
-            destination,
+            team.slack.teamChannel,
         );
-    }
-
-    private async handleError(ctx: HandlerContext, error, teamChannel: string) {
-        return await handleQMError(new ChannelMessageClient(ctx).addDestination(teamChannel), error);
     }
 }

--- a/src/gluon/events/team/MemberRemovedFromTeam.ts
+++ b/src/gluon/events/team/MemberRemovedFromTeam.ts
@@ -7,6 +7,7 @@ import {
 import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {QMConfig} from "../../../config/QMConfig";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {BitbucketConfigurationService} from "../../services/bitbucket/BitbucketConfigurationService";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -17,7 +18,7 @@ import {
     QMProject,
 } from "../../util/project/Project";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {ChannelMessageClient, handleQMError} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTenant} from "../../util/shared/Tenants";
 import {getDevOpsEnvironmentDetails, QMTeam} from "../../util/team/Teams";
 import {EventToGluon} from "../../util/transform/EventToGluon";

--- a/src/gluon/events/team/MembersAddedToTeam.ts
+++ b/src/gluon/events/team/MembersAddedToTeam.ts
@@ -8,6 +8,7 @@ import {EventHandler} from "@atomist/automation-client/lib/decorators";
 import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 import {addressSlackChannelsFromContext} from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {QMConfig} from "../../../config/QMConfig";
+import {ChannelMessageClient} from "../../../context/QMMessageClient";
 import {BitbucketConfigurationService} from "../../services/bitbucket/BitbucketConfigurationService";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -20,7 +21,6 @@ import {
 } from "../../util/project/Project";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
 import {
-    ChannelMessageClient,
     handleQMError,
     QMError,
 } from "../../util/shared/Error";

--- a/src/gluon/events/team/MembershipRequestClosed.ts
+++ b/src/gluon/events/team/MembershipRequestClosed.ts
@@ -13,6 +13,7 @@ import {
     addressSlackUsersFromContext,
 } from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {SlackMessage} from "@atomist/slack-messages";
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
 import {GluonService} from "../../services/gluon/GluonService";
 import {QMColours} from "../../util/QMColour";
@@ -21,8 +22,7 @@ import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
 import {
     handleQMError,
     QMError,
-    ResponderMessageClient,
-} from "../../util/shared/Error";
+    } from "../../util/shared/Error";
 
 @CommandHandler("Close a membership request")
 export class MembershipRequestClosed extends BaseQMEvent implements HandleCommand<HandlerResult> {

--- a/src/gluon/events/team/TeamOpenShiftCloudMigrated.ts
+++ b/src/gluon/events/team/TeamOpenShiftCloudMigrated.ts
@@ -1,4 +1,7 @@
-import {OpenshiftListResource, OpenshiftResource} from "@absa-subatomic/openshift-api/build/src/resources/OpenshiftResource";
+import {
+    OpenshiftListResource,
+    OpenshiftResource,
+} from "@absa-subatomic/openshift-api/build/src/resources/OpenshiftResource";
 import {
     addressSlackChannelsFromContext,
     buttonForCommand,
@@ -12,6 +15,10 @@ import {HandleEvent} from "@atomist/automation-client/lib/HandleEvent";
 
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
+import {
+    ChannelMessageClient,
+    SimpleQMMessageClient,
+} from "../../../context/QMMessageClient";
 import {ReRunMigrateTeamCloud} from "../../commands/team/ReRunMigrateTeamCloud";
 import {QMApplication} from "../../services/gluon/ApplicationService";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -40,11 +47,7 @@ import {
 } from "../../util/project/Project";
 import {QMColours} from "../../util/QMColour";
 import {BaseQMEvent} from "../../util/shared/BaseQMEvent";
-import {
-    ChannelMessageClient,
-    handleQMError,
-    QMMessageClient,
-} from "../../util/shared/Error";
+import {handleQMError} from "../../util/shared/Error";
 import {QMTenant} from "../../util/shared/Tenants";
 import {
     DevOpsEnvironmentDetails,
@@ -124,7 +127,7 @@ export class TeamOpenShiftCloudMigrated extends BaseQMEvent implements HandleEve
         }
     }
 
-    private async createMigrateTeamToCloudTasks(qmMessageClient: QMMessageClient, team: QMTeam, previousCloud: string) {
+    private async createMigrateTeamToCloudTasks(qmMessageClient: SimpleQMMessageClient, team: QMTeam, previousCloud: string) {
         const taskListMessage: TaskListMessage = new TaskListMessage(`🚀 Migrating Team to cloud *${team.openShiftCloud}* started:`,
             qmMessageClient);
         const taskRunner: TaskRunner = new TaskRunner(taskListMessage);
@@ -241,10 +244,6 @@ export class TeamOpenShiftCloudMigrated extends BaseQMEvent implements HandleEve
                 taskRunner.addTask(new ConfigurePackageDeploymentPipelineInJenkins(application, project, jenkinsDeploymentJobTemplates), "Configure Package Deployment Jobs in Jenkins");
             }
         }
-    }
-
-    private async handleError(ctx: HandlerContext, error, teamChannel: string) {
-        return await handleQMError(new ChannelMessageClient(ctx).addDestination(teamChannel), error);
     }
 
     private createRetryMigrationButton(correlationId: string, teamCloudMigrationEvent: string) {

--- a/src/gluon/services/member/OnboardMemberService.ts
+++ b/src/gluon/services/member/OnboardMemberService.ts
@@ -1,35 +1,28 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
-import {
-    addressSlackChannelsFromContext,
-} from "@atomist/automation-client/lib/spi/message/MessageClient";
-import {inviteUserToSlackChannel} from "@atomist/sdm-pack-lifecycle/lib/handlers/command/slack/AssociateRepo";
-import {loadChannelIdByChannelName} from "../../util/team/Teams";
+import {logger} from "@atomist/automation-client";
+import {QMContext} from "../../../context/QMContext";
 
 export class OnboardMemberService {
 
-    public async inviteUserToSecondarySlackChannel(ctx: HandlerContext,
+    public async inviteUserToSecondarySlackChannel(ctx: QMContext,
+                                                   slackTeamId: string,
                                                    newMemberFirstName: string,
                                                    channelName: string,
                                                    slackUserID: string,
                                                    slackScreenName: string) {
 
-        const destination = await addressSlackChannelsFromContext(ctx, channelName);
         try {
             logger.info(`Added team member! Inviting to channel [${channelName}] -> member [${slackUserID}]`);
-            const slackChannelId = await loadChannelIdByChannelName(ctx, channelName);
+            const slackChannelId = await ctx.graphClient.slackChannelIdFromChannelName(channelName);
             logger.info("Channel ID: " + slackChannelId);
 
-            await inviteUserToSlackChannel(ctx,
-                destination.team, // NOTE: this is the Slack Workspace ID not the Atomist Workspace ID (they used to be the same)
-                slackChannelId,
-                slackUserID);
+            await ctx.graphClient.inviteUserToSlackChannel(slackTeamId, slackChannelId, slackUserID);
 
             return channelName;
         } catch (error) {
             logger.warn(`inviteUserToCustomSlackChannel warning: ${JSON.stringify(error)}`);
             const msg = `Invitation to channel *${channelName}* failed for *${slackScreenName}*.\n Note, private channels do not currently support automatic user invitation.\n` +
                 `Please invite the user to this slack channel manually.`;
-            return await ctx.messageClient.send(msg, destination);
+            return await ctx.messageClient.channelMessageClient.sendToChannels(msg, [channelName]);
         }
     }
 }

--- a/src/gluon/services/member/OnboardMemberService.ts
+++ b/src/gluon/services/member/OnboardMemberService.ts
@@ -22,7 +22,7 @@ export class OnboardMemberService {
             logger.warn(`inviteUserToCustomSlackChannel warning: ${JSON.stringify(error)}`);
             const msg = `Invitation to channel *${channelName}* failed for *${slackScreenName}*.\n Note, private channels do not currently support automatic user invitation.\n` +
                 `Please invite the user to this slack channel manually.`;
-            return await ctx.messageClient.channelMessageClient.sendToChannels(msg, [channelName]);
+            return await ctx.messageClient.sendToChannels(msg, [channelName]);
         }
     }
 }

--- a/src/gluon/services/member/OnboardMemberService.ts
+++ b/src/gluon/services/member/OnboardMemberService.ts
@@ -22,7 +22,7 @@ export class OnboardMemberService {
             logger.warn(`inviteUserToCustomSlackChannel warning: ${JSON.stringify(error)}`);
             const msg = `Invitation to channel *${channelName}* failed for *${slackScreenName}*.\n Note, private channels do not currently support automatic user invitation.\n` +
                 `Please invite the user to this slack channel manually.`;
-            return await ctx.messageClient.sendToChannels(msg, [channelName]);
+            return await ctx.messageClient.sendToChannels(msg, channelName);
         }
     }
 }

--- a/src/gluon/services/team/AddMemberToTeamService.ts
+++ b/src/gluon/services/team/AddMemberToTeamService.ts
@@ -1,12 +1,12 @@
 import {HandlerContext, logger} from "@atomist/automation-client";
 import {
     addressSlackChannelsFromContext,
-    addressSlackUsersFromContext,
     buttonForCommand,
 } from "@atomist/automation-client/lib/spi/message/MessageClient";
 import {inviteUserToSlackChannel} from "@atomist/sdm-pack-lifecycle/lib/handlers/command/slack/AssociateRepo";
 import {SlackMessage} from "@atomist/slack-messages";
 import {inspect} from "util";
+import {QMContext} from "../../../context/QMContext";
 import {isSuccessCode} from "../../../http/Http";
 import {CommandIntent} from "../../commands/CommandIntent";
 import {OnboardMember} from "../../commands/member/OnboardMember";
@@ -26,7 +26,7 @@ export class AddMemberToTeamService {
     constructor(private gluonService = new GluonService()) {
     }
 
-    public async getNewMemberGluonDetails(ctx: HandlerContext, chatId: string, teamChannel: string) {
+    public async getNewMemberGluonDetails(ctx: QMContext, chatId: string, teamChannel: string) {
         try {
             return await this.gluonService.members.gluonMemberFromScreenName(chatId);
         } catch (error) {
@@ -139,8 +139,7 @@ They have been sent a request to onboard, once they've successfully onboarded yo
         }
     }
 
-    private async onboardMessage(ctx, chatId: string, teamChannel: string) {
-        const destination = await addressSlackUsersFromContext(ctx, chatId);
+    private async onboardMessage(ctx: QMContext, chatId: string, teamChannel: string) {
         const msg: SlackMessage = {
             text: `Someone tried to add you to the team channel ${teamChannel}.`,
             attachments: [{
@@ -162,6 +161,6 @@ Click the button below to do that now.
                 ],
             }],
         };
-        return await ctx.messageClient.send(msg, destination);
+        return await ctx.messageClient.sendToUsers(msg, chatId);
     }
 }

--- a/src/gluon/services/team/RemoveMemberFromTeamService.ts
+++ b/src/gluon/services/team/RemoveMemberFromTeamService.ts
@@ -23,7 +23,7 @@ export class RemoveMemberFromTeamService {
     constructor(private gluonService = new GluonService()) {
     }
 
-    public async getMemberGluonDetails(ctx: HandlerContext, chatId: string) {
+    public async getMemberGluonDetails(chatId: string) {
         try {
             return await this.gluonService.members.gluonMemberFromScreenName(chatId);
         } catch (error) {

--- a/src/gluon/tasks/Task.ts
+++ b/src/gluon/tasks/Task.ts
@@ -1,4 +1,4 @@
-import {HandlerContext} from "@atomist/automation-client";
+import {QMContext} from "../../context/QMContext";
 import {QMError} from "../util/shared/Error";
 import {TaskListMessage} from "./TaskListMessage";
 
@@ -6,7 +6,7 @@ export abstract class Task {
 
     protected taskListMessage: TaskListMessage;
 
-    public async execute(ctx: HandlerContext): Promise<boolean> {
+    public async execute(ctx: QMContext): Promise<boolean> {
         if (this.taskListMessage === undefined) {
             throw new QMError("TaskListMessage is undefined. Cannot start taskRunner.");
         }
@@ -23,7 +23,7 @@ export abstract class Task {
         }
     }
 
-    protected abstract async executeTask(ctx: HandlerContext): Promise<boolean>;
+    protected abstract async executeTask(ctx: QMContext): Promise<boolean>;
 
     protected abstract configureTaskListMessage(taskListMessage: TaskListMessage);
 }

--- a/src/gluon/tasks/TaskListMessage.ts
+++ b/src/gluon/tasks/TaskListMessage.ts
@@ -1,8 +1,8 @@
 import {HandlerResult, logger} from "@atomist/automation-client";
 import {Attachment, SlackMessage} from "@atomist/slack-messages";
 import {v4 as uuid} from "uuid";
+import {SimpleQMMessageClient} from "../../context/QMMessageClient";
 import {QMColours} from "../util/QMColour";
-import {QMMessageClient} from "../util/shared/Error";
 
 export class TaskListMessage {
 
@@ -15,7 +15,7 @@ export class TaskListMessage {
     private readonly tasks: { [k: string]: Task };
     private readonly taskOrder: string[];
 
-    constructor(private titleMessage, private messageClient: QMMessageClient) {
+    constructor(private titleMessage, private messageClient: SimpleQMMessageClient) {
         this.messageId = uuid();
         this.tasks = {};
         this.taskOrder = [];

--- a/src/gluon/tasks/TaskRunner.ts
+++ b/src/gluon/tasks/TaskRunner.ts
@@ -1,5 +1,10 @@
 import {HandlerContext} from "@atomist/automation-client";
 import _ = require("lodash");
+import {
+    AtomistQMContext,
+    isQMContext,
+    QMContext,
+} from "../../context/QMContext";
 import {Task} from "./Task";
 import {TaskListMessage} from "./TaskListMessage";
 
@@ -31,11 +36,17 @@ export class TaskRunner {
         return this;
     }
 
-    public async execute(ctx: HandlerContext) {
+    public async execute(ctx: HandlerContext | QMContext) {
+        let context: QMContext;
+        if (isQMContext(ctx)) {
+            context = ctx;
+        } else {
+            context = new AtomistQMContext(ctx);
+        }
         await this.taskListMessage.display();
         try {
             for (const task of this.tasks) {
-                if (!await task.task.execute(ctx)) {
+                if (!await task.task.execute(context)) {
                     await this.taskListMessage.failRemainingTasks();
                     return false;
                 } else if (!_.isEmpty(task.taskKey)) {

--- a/src/gluon/tasks/bitbucket/ConfigureBitbucketProjectAccess.ts
+++ b/src/gluon/tasks/bitbucket/ConfigureBitbucketProjectAccess.ts
@@ -1,4 +1,4 @@
-import {HandlerContext} from "@atomist/automation-client";
+import {QMContext} from "../../../context/QMContext";
 import {BitbucketConfigurationService} from "../../services/bitbucket/BitbucketConfigurationService";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {userFromDomainUser} from "../../util/member/Members";
@@ -25,7 +25,7 @@ export class ConfigureBitbucketProjectAccess extends Task {
         this.taskListMessage.addTask(this.TASK_ADD_BITBUCKET_USERS, "\tAdd user permissions to Bitbucket Project");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
 
         const bitbucketProjectKey = this.project.bitbucketProject.key;
 

--- a/src/gluon/tasks/bitbucket/ConfigureBitbucketProjectRecommendedPractices.ts
+++ b/src/gluon/tasks/bitbucket/ConfigureBitbucketProjectRecommendedPractices.ts
@@ -1,4 +1,4 @@
-import {HandlerContext} from "@atomist/automation-client";
+import {QMContext} from "../../../context/QMContext";
 import {BitbucketConfigurationService} from "../../services/bitbucket/BitbucketConfigurationService";
 import {BitbucketService} from "../../services/bitbucket/BitbucketService";
 import {userFromDomainUser} from "../../util/member/Members";
@@ -27,7 +27,7 @@ export class ConfigureBitbucketProjectRecommendedPractices extends Task {
         this.taskListMessage.addTask(this.TASK_ADD_DEFAULT_REVIEWERS, "\tSet project default reviewers");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
 
         const bitbucketProjectKey = this.project.bitbucketProject.key;
 

--- a/src/gluon/tasks/packages/ConfigurePackageDeploymentPipelineInJenkins.ts
+++ b/src/gluon/tasks/packages/ConfigurePackageDeploymentPipelineInJenkins.ts
@@ -1,10 +1,6 @@
-import {
-    HandlerContext,
-    HandlerResult,
-    logger,
-    success,
-} from "@atomist/automation-client";
+import {HandlerResult, logger, success} from "@atomist/automation-client";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {QMFileTemplate} from "../../../template/QMTemplate";
 import {
     BitbucketFileService,
@@ -54,7 +50,7 @@ export class ConfigurePackageDeploymentPipelineInJenkins extends Task {
         this.taskListMessage.addTask(this.TASK_CREATE_JENKINS_JOB, "Create Jenkins Jobs");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         const owningTeam: QMTeam = await this.gluonService.teams.gluonTeamById(this.project.owningTeam.teamId);
         await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[owningTeam.openShiftCloud].openshiftNonProd);
 

--- a/src/gluon/tasks/packages/ConfigurePackageInOpenshift.ts
+++ b/src/gluon/tasks/packages/ConfigurePackageInOpenshift.ts
@@ -1,13 +1,12 @@
-import {OpenshiftListResource, OpenshiftResource} from "@absa-subatomic/openshift-api/build/src/resources/OpenshiftResource";
 import {
-    HandlerContext,
-    HandlerResult,
-    logger,
-    success,
-} from "@atomist/automation-client";
+    OpenshiftListResource,
+    OpenshiftResource,
+} from "@absa-subatomic/openshift-api/build/src/resources/OpenshiftResource";
+import {HandlerResult, logger, success} from "@atomist/automation-client";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
 
+import {QMContext} from "../../../context/QMContext";
 import {QMTemplate} from "../../../template/QMTemplate";
 import {ImageStream} from "../../events/packages/package-configuration-request/PackageConfigurationRequestedEvent";
 import {GluonService} from "../../services/gluon/GluonService";
@@ -47,7 +46,7 @@ export class ConfigurePackageInOpenshift extends Task {
         this.taskListMessage.addTask(this.TASK_ADD_RESOURCES_TO_ENVIRONMENTS, "Add Resources To Deployment Environments");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         if (this.taskListMessage === undefined) {
             throw new QMError("TaskListMessage is undefined.");
         }

--- a/src/gluon/tasks/packages/ConfigurePackagePipelineInJenkins.ts
+++ b/src/gluon/tasks/packages/ConfigurePackagePipelineInJenkins.ts
@@ -1,11 +1,7 @@
-import {
-    HandlerContext,
-    HandlerResult,
-    logger,
-    success,
-} from "@atomist/automation-client";
+import {HandlerResult, logger, success} from "@atomist/automation-client";
 import _ = require("lodash");
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {QMFileTemplate} from "../../../template/QMTemplate";
 import {
     BitbucketFileService,
@@ -50,7 +46,7 @@ export class ConfigurePackagePipelineInJenkins extends Task {
         this.taskListMessage.addTask(this.TASK_CREATE_JENKINS_JOB, "Create Jenkins Job");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         const owningTeam: QMTeam = await this.gluonService.teams.gluonTeamById(this.project.owningTeam.teamId);
         await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[owningTeam.openShiftCloud].openshiftNonProd);
 

--- a/src/gluon/tasks/packages/PatchPackageBuildConfigImage.ts
+++ b/src/gluon/tasks/packages/PatchPackageBuildConfigImage.ts
@@ -1,7 +1,7 @@
 import {OpenshiftResource} from "@absa-subatomic/openshift-api/build/src/resources/OpenshiftResource";
-import {HandlerContext} from "@atomist/automation-client";
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 
+import {QMContext} from "../../../context/QMContext";
 import {OCService} from "../../services/openshift/OCService";
 import {getBuildConfigName} from "../../util/packages/Applications";
 import {QMError} from "../../util/shared/Error";
@@ -30,7 +30,7 @@ export class PatchPackageBuildConfigImage extends Task {
         this.taskListMessage.addTask(this.TASK_PATCH_BUILD_CONFIG, `Patch BuildConfig *${devopsProjectId}/${buildConfigName}*`);
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         if (this.taskListMessage === undefined) {
             throw new QMError("TaskListMessage is undefined.");
         }

--- a/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
+++ b/src/gluon/tasks/project/ConfigureJenkinsForProject.ts
@@ -1,7 +1,8 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import _ = require("lodash");
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {isSuccessCode} from "../../../http/Http";
 import {QMFileTemplate} from "../../../template/QMTemplate";
 import {
@@ -55,7 +56,7 @@ export class ConfigureJenkinsForProject extends Task {
         this.taskListMessage.addTask(this.TASK_ADD_JENKINS_CREDENTIALS, "\tAdd project environment credentials to Jenkins");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         const teamDevOpsProjectId = getDevOpsEnvironmentDetails(this.jenkinsProjectDetails.teams[0].name).openshiftProjectId;
 
         await this.ocService.setOpenShiftDetails(this.openshiftEnvironment);

--- a/src/gluon/tasks/project/CreateOpenshiftEnvironments.ts
+++ b/src/gluon/tasks/project/CreateOpenshiftEnvironments.ts
@@ -1,6 +1,7 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import {inspect} from "util";
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
+import {QMContext} from "../../../context/QMContext";
 import {isSuccessCode} from "../../../http/Http";
 import {OCService} from "../../services/openshift/OCService";
 import {
@@ -39,7 +40,7 @@ export class CreateOpenshiftEnvironments extends Task {
         this.taskListMessage.addTask(this.TASK_CREATE_POD_NETWORK, "\tCreate project/devops pod network");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         await this.createOpenshiftEnvironments();
 
         await this.createPodNetwork();

--- a/src/gluon/tasks/project/CreateOpenshiftResourcesInProject.ts
+++ b/src/gluon/tasks/project/CreateOpenshiftResourcesInProject.ts
@@ -1,7 +1,7 @@
 import {OpenshiftListResource} from "@absa-subatomic/openshift-api/build/src/resources/OpenshiftResource";
-import {HandlerContext} from "@atomist/automation-client";
 import _ = require("lodash");
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
+import {QMContext} from "../../../context/QMContext";
 import {OCService} from "../../services/openshift/OCService";
 import {GenericOpenshiftResourceService} from "../../services/projects/GenericOpenshiftResourceService";
 import {OpenShiftProjectNamespace} from "../../util/project/Project";
@@ -31,7 +31,7 @@ export class CreateOpenshiftResourcesInProject extends Task {
         }
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         if (this.taskListMessage === undefined) {
             throw new QMError("TaskListMessage is undefined.");
         }

--- a/src/gluon/tasks/team/AddJenkinsToDevOpsEnvironment.ts
+++ b/src/gluon/tasks/team/AddJenkinsToDevOpsEnvironment.ts
@@ -1,5 +1,6 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {JenkinsDevOpsCredentialsService} from "../../services/jenkins/JenkinsDevOpsCredentialsService";
 import {OCService} from "../../services/openshift/OCService";
 import {getSubatomicJenkinsServiceAccountName} from "../../util/jenkins/Jenkins";
@@ -31,7 +32,7 @@ export class AddJenkinsToDevOpsEnvironment extends Task {
         taskListMessage.addTask(this.TASK_CONFIG_JENKINS, "\tConfigure Jenkins");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
 
         const projectId = getDevOpsEnvironmentDetails(this.team.name).openshiftProjectId;
         logger.info(`Working with OpenShift project Id: ${projectId}`);

--- a/src/gluon/tasks/team/AddJenkinsToProdEnvironment.ts
+++ b/src/gluon/tasks/team/AddJenkinsToProdEnvironment.ts
@@ -1,7 +1,8 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import _ = require("lodash");
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {
     JenkinsCredentialsFolder,
     JenkinsService,
@@ -44,7 +45,7 @@ export class AddJenkinsToProdEnvironment extends Task {
         taskListMessage.addTask(this.TASK_ADD_JENKINS_CREDENTIALS, "\tAdd project environment credentials to Jenkins");
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         const teamDevOpsNonProd = getDevOpsEnvironmentDetails(this.projectDetails.team.name).openshiftProjectId;
         const teamDevOpsProd = getDevOpsEnvironmentDetailsProd(this.projectDetails.team.name).openshiftProjectId;
         logger.info(`Working with OpenShift project Id: ${teamDevOpsProd}`);

--- a/src/gluon/tasks/team/AddMemberToTeamTask.ts
+++ b/src/gluon/tasks/team/AddMemberToTeamTask.ts
@@ -1,11 +1,8 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
+import {QMContext} from "../../../context/QMContext";
 import {GluonService} from "../../services/gluon/GluonService";
 import {AddMemberToTeamService} from "../../services/team/AddMemberToTeamService";
-import {
-    getScreenName,
-    loadScreenNameByUserId,
-    MemberRole,
-} from "../../util/member/Members";
+import {getScreenName, MemberRole} from "../../util/member/Members";
 import {getTeamSlackChannel} from "../../util/team/Teams";
 import {Task} from "../Task";
 import {TaskListMessage} from "../TaskListMessage";
@@ -29,7 +26,7 @@ export class AddMemberToTeamTask extends Task {
         taskListMessage.addTask(this.TASK_ADD_USER_TO_TEAM, "Add user to team with role: " + this.memberRole.toString());
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
 
         const team = await this.gluonService.teams.gluonTeamByName(this.teamName);
 
@@ -39,7 +36,7 @@ export class AddMemberToTeamTask extends Task {
 
         const screenName = getScreenName(this.slackName);
 
-        const chatId = await loadScreenNameByUserId(ctx, screenName);
+        const chatId = await ctx.graphClient.slackScreenNameFromSlackUserId(screenName);
 
         logger.info(`Got ChatId: ${chatId}`);
 

--- a/src/gluon/tasks/team/CreateConfigServer.ts
+++ b/src/gluon/tasks/team/CreateConfigServer.ts
@@ -1,6 +1,7 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import * as _ from "lodash";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {OCService} from "../../services/openshift/OCService";
 import {getDevOpsEnvironmentDetails} from "../../util/team/Teams";
 import {Task} from "../Task";
@@ -27,7 +28,7 @@ export class CreateConfigServer extends Task {
         taskListMessage.addTask(this.TASK_CREATE_DEPLOYMENT_CONFIG, `\tCreate Config Server Deployment Config`);
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
 
         await this.ocService.setOpenShiftDetails(QMConfig.subatomic.openshiftClouds[this.openShiftCloud].openshiftNonProd);
         const devOpsProjectId = getDevOpsEnvironmentDetails(this.gluonTeamName).openshiftProjectId;

--- a/src/gluon/tasks/team/CreateTeamDevOpsEnvironment.ts
+++ b/src/gluon/tasks/team/CreateTeamDevOpsEnvironment.ts
@@ -1,6 +1,7 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import {OpenShiftConfig} from "../../../config/OpenShiftConfig";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {OCService} from "../../services/openshift/OCService";
 import {QMError, QMErrorType} from "../../util/shared/Error";
 import {
@@ -32,7 +33,7 @@ export class CreateTeamDevOpsEnvironment extends Task {
         taskListMessage.addTask(this.TASK_SECRETS, `\tAdd Secrets`);
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         const projectId = this.devopsEnvironmentDetails.openshiftProjectId;
         logger.info(`Working with OpenShift project Id: ${projectId}`);
 

--- a/src/gluon/tasks/team/RecreateJenkinsDevOpsCredentials.ts
+++ b/src/gluon/tasks/team/RecreateJenkinsDevOpsCredentials.ts
@@ -1,5 +1,6 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
 import {QMConfig} from "../../../config/QMConfig";
+import {QMContext} from "../../../context/QMContext";
 import {GluonService} from "../../services/gluon/GluonService";
 import {
     JenkinsCredentialsAction,
@@ -36,7 +37,7 @@ export class RecreateJenkinsDevOpsCredentials extends Task {
         taskListMessage.addTask(this.TASK_CREATE_PRODUCTION_CREDENTIALS, `\tCreate any required production credentials`);
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
 
         const teamDevOpsProjectId = getDevOpsEnvironmentDetails(this.gluonTeamName).openshiftProjectId;
 

--- a/src/gluon/tasks/team/RemoveMemberFromTeamTask.ts
+++ b/src/gluon/tasks/team/RemoveMemberFromTeamTask.ts
@@ -1,11 +1,8 @@
-import {HandlerContext, logger} from "@atomist/automation-client";
+import {logger} from "@atomist/automation-client";
+import {QMContext} from "../../../context/QMContext";
 import {GluonService} from "../../services/gluon/GluonService";
 import {RemoveMemberFromTeamService} from "../../services/team/RemoveMemberFromTeamService";
-import {
-    getScreenName,
-    loadScreenNameByUserId,
-    MemberRole,
-} from "../../util/member/Members";
+import {getScreenName, MemberRole} from "../../util/member/Members";
 import {QMError} from "../../util/shared/Error";
 import {isMember, isOwner} from "../../util/team/Teams";
 import {Task} from "../Task";
@@ -30,11 +27,11 @@ export class RemoveMemberFromTeamTask extends Task {
         taskListMessage.addTask(this.TASK_REMOVE_USER_FROM_TEAM, "Remove user from team with role: " + this.memberRole.toString());
     }
 
-    protected async executeTask(ctx: HandlerContext): Promise<boolean> {
+    protected async executeTask(ctx: QMContext): Promise<boolean> {
         const team = await this.gluonService.teams.gluonTeamByName(this.teamName);
         const screenName = getScreenName(this.slackName);
-        const chatId = await loadScreenNameByUserId(ctx, screenName);
-        const memberToRemove = await this.removeMemberFromTeamService.getMemberGluonDetails(ctx, chatId);
+        const chatId = await ctx.graphClient.slackScreenNameFromSlackUserId(screenName);
+        const memberToRemove = await this.removeMemberFromTeamService.getMemberGluonDetails(chatId);
         const actioningMember = await this.gluonService.members.gluonMemberFromScreenName(this.screenName);
 
         if (isOwner(team, actioningMember.memberId)) {

--- a/src/gluon/util/recursiveparam/RecursiveParameterRequestCommand.ts
+++ b/src/gluon/util/recursiveparam/RecursiveParameterRequestCommand.ts
@@ -11,9 +11,10 @@ import {
 import {SlackMessage} from "@atomist/slack-messages";
 import _ = require("lodash");
 import uuid = require("uuid");
+import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {QMColours} from "../QMColour";
 import {BaseQMComand} from "../shared/BaseQMCommand";
-import {handleQMError, QMError, ResponderMessageClient} from "../shared/Error";
+import {handleQMError, QMError} from "../shared/Error";
 import {ParameterStatusDisplay} from "./ParameterStatusDisplay";
 import {RecursiveSetterResult} from "./RecursiveSetterResult";
 

--- a/test/gluon/TestQMContext.ts
+++ b/test/gluon/TestQMContext.ts
@@ -27,45 +27,80 @@ export class TestQMContext implements QMContext {
 
 export class TestQMMessageClient implements QMMessageClient {
 
-    public responseMessagesSent: SlackMessage[] = [];
-    public channelMessagesSent: SlackMessage[] = [];
-    public userMessagesSent: SlackMessage[] = [];
+    public responseMessagesSent: MessageSent[] = [];
+    public channelMessagesSent: DirectedMessageSent[] = [];
+    public userMessagesSent: DirectedMessageSent[] = [];
 
     public createChannelMessageClient(): DirectedQMMessageClient {
-        return new TestDirectedQMMessageClient();
+        return new TestChannelQMMessageClient(this);
     }
 
     public createResponderMessageClient(): SimpleQMMessageClient {
-        return new TestSimpleQMMessageClient();
+        return new TestSimpleQMMessageClient(this);
     }
 
     public createUserMessageClient(): DirectedQMMessageClient {
-        return new TestDirectedQMMessageClient();
+        return new TestUserQMMessageClient(this);
     }
 
     public async respond(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
+        return this.respondWithLabel(message, options, "internal");
+    }
+
+    public async respondWithLabel(message: string | SlackMessage, options?: MessageOptions, label?: string): Promise<HandlerResult> {
         if (typeof message === "string") {
-            this.responseMessagesSent.push({text: message});
+            this.responseMessagesSent.push({
+                    message: {text: message},
+                    label,
+                },
+            );
         } else {
-            this.responseMessagesSent.push(message);
+            this.responseMessagesSent.push({
+                message,
+                label,
+            });
         }
         return await success();
     }
 
     public async sendToChannels(message: string | SlackMessage, channels: string[], options?: MessageOptions): Promise<HandlerResult> {
+        return this.sendToChannelsWithLabel(message, channels, options, "internal");
+    }
+
+    public async sendToChannelsWithLabel(message: string | SlackMessage, channels: string[], options?: MessageOptions, label?: string): Promise<HandlerResult> {
         if (typeof message === "string") {
-            this.channelMessagesSent.push({text: message});
+            this.channelMessagesSent.push({
+                message: {text: message},
+                label,
+                destinations: channels,
+            });
         } else {
-            this.channelMessagesSent.push(message);
+            this.channelMessagesSent.push({
+                message,
+                label,
+                destinations: channels,
+            });
         }
         return await success();
     }
 
     public async sendToUsers(message: string | SlackMessage, users: string[], options?: MessageOptions): Promise<HandlerResult> {
+        return this.sendToUsersWithLabel(message, users, options, "label");
+    }
+
+    public async sendToUsersWithLabel(message: string | SlackMessage, users: string[], options?: MessageOptions, label?: string): Promise<HandlerResult> {
         if (typeof message === "string") {
-            this.userMessagesSent.push({text: message});
+            this.userMessagesSent.push({
+                message: {text: message},
+                label,
+                destinations: users,
+            });
         } else {
-            this.userMessagesSent.push(message);
+            this.userMessagesSent.push({
+                message,
+                label,
+                destinations: users,
+            });
         }
         return await success();
     }
@@ -116,30 +151,23 @@ export class TestQMGraphClient implements QMGraphClient {
 }
 
 export class TestSimpleQMMessageClient implements SimpleQMMessageClient {
-    public messagesSent: SlackMessage[] = [];
+    constructor(private messageClientBase: TestQMMessageClient) {
+    }
 
     public async send(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
-        if (typeof message === "string") {
-            this.messagesSent.push({text: message});
-        } else {
-            this.messagesSent.push(message);
-        }
-
-        return await success();
+        return this.messageClientBase.respondWithLabel(message, options, "external");
     }
 }
 
-export class TestDirectedQMMessageClient implements DirectedQMMessageClient {
-    public messagesSent: SlackMessage[] = [];
+export class TestUserQMMessageClient implements DirectedQMMessageClient {
+
     public destinations: string[] = [];
 
+    constructor(private messageClientBase: TestQMMessageClient) {
+    }
+
     public async send(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
-        if (typeof message === "string") {
-            this.messagesSent.push({text: message});
-        } else {
-            this.messagesSent.push(message);
-        }
-        return await success();
+        return this.messageClientBase.sendToUsersWithLabel(message, this.destinations, options, "external");
     }
 
     public addDestination(user: string) {
@@ -151,4 +179,35 @@ export class TestDirectedQMMessageClient implements DirectedQMMessageClient {
         this.destinations = [];
         return this;
     }
+}
+
+export class TestChannelQMMessageClient implements DirectedQMMessageClient {
+
+    public destinations: string[] = [];
+
+    constructor(private messageClientBase: TestQMMessageClient) {
+    }
+
+    public async send(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
+        return this.messageClientBase.sendToChannelsWithLabel(message, this.destinations, options, "external");
+    }
+
+    public addDestination(user: string) {
+        this.destinations.push(user);
+        return this;
+    }
+
+    public clearDestinations() {
+        this.destinations = [];
+        return this;
+    }
+}
+
+export interface MessageSent {
+    message: SlackMessage;
+    label: string;
+}
+
+export interface DirectedMessageSent extends MessageSent {
+    destinations: string[];
 }

--- a/test/gluon/TestQMContext.ts
+++ b/test/gluon/TestQMContext.ts
@@ -1,0 +1,143 @@
+import {
+    HandlerResult,
+    MessageOptions,
+    success,
+} from "@atomist/automation-client";
+import {SlackMessage} from "@atomist/slack-messages";
+import {QMContext} from "../../src/context/QMContext";
+import {QMGraphClient} from "../../src/context/QMGraphClient";
+import {
+    ChannelMessageClient,
+    QMMessageClient,
+    SimpleQMMessageClient,
+    UserMessageClient,
+} from "../../src/context/QMMessageClient";
+
+export class TestQMContext implements QMContext {
+
+    public eventsRaised: Array<{ eventData: any, eventName: string }> = [];
+    public graphClient: TestQMGraphClient = new TestQMGraphClient();
+    public messageClient: TestQMMessageClient = new TestQMMessageClient();
+
+    public async raiseEvent(eventData: any, eventName: string): Promise<HandlerResult> {
+        this.eventsRaised.push({eventName, eventData});
+        return await success();
+    }
+
+}
+
+export class TestQMMessageClient implements QMMessageClient {
+    public channelMessageClient: TestChannelMessageClient = new TestChannelMessageClient();
+    public responderMessageClient: TestSimpleQMMessageClient = new TestSimpleQMMessageClient();
+    public userMessageClient: TestUserMessageClient = new TestUserMessageClient();
+}
+
+export class TestQMGraphClient implements QMGraphClient {
+    public usersInvitedToSlackChannel: Array<{ slackChannelId: string, slackUserId: string }> = [];
+    public usersKickedFromSlackChannel: Array<{ slackChannelId: string, slackUserId: string }> = [];
+    public inviteUserToChannelResponse: Array<{ success: boolean, body: any }> = [];
+    public kickUserFromChannelResponse: Array<{ success: boolean, body: any }> = [];
+
+    public async inviteUserToSlackChannel(slackTeamId: string, slackChannelId: string, slackUserId: string): Promise<any> {
+        this.usersInvitedToSlackChannel.push({slackChannelId, slackUserId});
+        if (this.inviteUserToChannelResponse.length === 0) {
+            return success();
+        } else {
+            const response = this.inviteUserToChannelResponse.pop();
+            if (!response.success) {
+                throw response.body;
+            } else {
+                return await response.body;
+            }
+        }
+    }
+
+    public async kickUserFromSlackChannel(slackTeamId: string, slackChannelId: string, slackUserId: string): Promise<any> {
+        this.usersKickedFromSlackChannel.push({slackChannelId, slackUserId});
+        if (this.inviteUserToChannelResponse.length === 0) {
+            return await "kicked";
+        } else {
+            const response = this.kickUserFromChannelResponse.pop();
+            if (!response.success) {
+                throw response.body;
+            } else {
+                return response.body;
+            }
+        }
+    }
+
+    public async slackChannelIdFromChannelName(channelName: string): Promise<string> {
+        return await channelName + "ID";
+    }
+
+    public async slackScreenNameFromSlackUserId(slackUserId: string): Promise<string> {
+        return await slackUserId + "ID";
+    }
+
+}
+
+export class TestSimpleQMMessageClient implements SimpleQMMessageClient {
+    public messagesSent: SlackMessage[] = [];
+
+    public async send(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
+        if (typeof message === "string") {
+            this.messagesSent.push({text: message});
+        } else {
+            this.messagesSent.push(message);
+        }
+
+        return await success();
+    }
+}
+
+export class TestChannelMessageClient extends ChannelMessageClient {
+    public messagesSent: SlackMessage[] = [];
+
+    constructor() {
+        super(null);
+    }
+
+    public async send(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
+        if (typeof message === "string") {
+            this.messagesSent.push({text: message});
+        } else {
+            this.messagesSent.push(message);
+        }
+        return await success();
+    }
+
+    public async sendToChannels(message: (string | SlackMessage), channels: string[], options?: MessageOptions) {
+        if (typeof message === "string") {
+            this.messagesSent.push({text: message});
+        } else {
+            this.messagesSent.push(message);
+        }
+        return await success();
+    }
+}
+
+export class TestUserMessageClient extends UserMessageClient {
+    public messagesSent: SlackMessage[] = [];
+
+    constructor() {
+        super(null);
+    }
+
+    public async send(message: string | SlackMessage, options?: MessageOptions): Promise<HandlerResult> {
+        if (typeof message === "string") {
+            this.messagesSent.push({text: message});
+        } else {
+            this.messagesSent.push(message);
+        }
+        return await success();
+    }
+
+    public async sendToUsers(message: (string | SlackMessage), users: string[], options?: MessageOptions) {
+        if (typeof message === "string") {
+            this.messagesSent.push({text: message});
+        } else {
+            this.messagesSent.push(message);
+        }
+        return await success();
+    }
+}

--- a/test/gluon/TestQMContext.ts
+++ b/test/gluon/TestQMContext.ts
@@ -63,8 +63,14 @@ export class TestQMMessageClient implements QMMessageClient {
         return await success();
     }
 
-    public async sendToChannels(message: string | SlackMessage, channels: string[], options?: MessageOptions): Promise<HandlerResult> {
-        return this.sendToChannelsWithLabel(message, channels, options, "internal");
+    public async sendToChannels(message: string | SlackMessage, channels: string | string[], options?: MessageOptions): Promise<HandlerResult> {
+        let destinations: string[];
+        if (typeof channels === "string") {
+            destinations = [channels];
+        } else {
+            destinations = channels;
+        }
+        return this.sendToChannelsWithLabel(message, destinations, options, "internal");
     }
 
     public async sendToChannelsWithLabel(message: string | SlackMessage, channels: string[], options?: MessageOptions, label?: string): Promise<HandlerResult> {
@@ -85,7 +91,13 @@ export class TestQMMessageClient implements QMMessageClient {
     }
 
     public async sendToUsers(message: string | SlackMessage, users: string[], options?: MessageOptions): Promise<HandlerResult> {
-        return this.sendToUsersWithLabel(message, users, options, "label");
+        let destinations: string[];
+        if (typeof users === "string") {
+            destinations = [users];
+        } else {
+            destinations = users;
+        }
+        return this.sendToUsersWithLabel(message, destinations, options, "label");
     }
 
     public async sendToUsersWithLabel(message: string | SlackMessage, users: string[], options?: MessageOptions, label?: string): Promise<HandlerResult> {

--- a/test/gluon/TestQMContext.ts
+++ b/test/gluon/TestQMContext.ts
@@ -13,7 +13,7 @@ import {
 } from "../../src/context/QMMessageClient";
 
 export class TestQMContext implements QMContext {
-
+    public descriminator: "QMContext";
     public eventsRaised: Array<{ eventData: any, eventName: string }> = [];
     public graphClient: TestQMGraphClient = new TestQMGraphClient();
     public messageClient: TestQMMessageClient = new TestQMMessageClient();

--- a/test/gluon/commands/member/OnboardMemberTest.ts
+++ b/test/gluon/commands/member/OnboardMemberTest.ts
@@ -28,6 +28,6 @@ describe("Onboard new member test", () => {
 
         gluon.isDone();
 
-        assert.equal(context.messageClient.responseMessagesSent[0].text, "🚀 Welcome to the Subatomic environment *Peter*!\n\nYou have been added to the Subatomic community channel/s:\n *sub-discussion*\n\nNext steps are to either join an existing team or create a new one.");
+        assert.equal(context.messageClient.responseMessagesSent[0].message.text, "🚀 Welcome to the Subatomic environment *Peter*!\n\nYou have been added to the Subatomic community channel/s:\n *sub-discussion*\n\nNext steps are to either join an existing team or create a new one.");
     });
 });

--- a/test/gluon/commands/member/OnboardMemberTest.ts
+++ b/test/gluon/commands/member/OnboardMemberTest.ts
@@ -28,6 +28,6 @@ describe("Onboard new member test", () => {
 
         gluon.isDone();
 
-        assert.equal(context.messageClient.responderMessageClient.messagesSent[0].text, "🚀 Welcome to the Subatomic environment *Peter*!\n\nYou have been added to the Subatomic community channel/s:\n *sub-discussion*\n\nNext steps are to either join an existing team or create a new one.");
+        assert.equal(context.messageClient.responseMessagesSent[0].text, "🚀 Welcome to the Subatomic environment *Peter*!\n\nYou have been added to the Subatomic community channel/s:\n *sub-discussion*\n\nNext steps are to either join an existing team or create a new one.");
     });
 });

--- a/test/gluon/commands/member/OnboardMemberTest.ts
+++ b/test/gluon/commands/member/OnboardMemberTest.ts
@@ -1,85 +1,33 @@
-import {SlackDestination} from "@atomist/automation-client";
-import * as assert from "power-assert";
+import assert = require("power-assert");
 import {QMConfig} from "../../../../src/config/QMConfig";
 import {OnboardMember} from "../../../../src/gluon/commands/member/OnboardMember";
-import {GluonService} from "../../../../src/gluon/services/gluon/GluonService";
-import {AwaitAxios} from "../../../../src/http/AwaitAxios";
-import {TestGraphClient} from "../../TestGraphClient";
-import {TestMessageClient} from "../../TestMessageClient";
+import {TestQMContext} from "../../TestQMContext";
 
-const MockAdapter = require("axios-mock-adapter");
+const nock = require("nock");
 
 describe("Onboard new member test", () => {
 
     it("should welcome new user (no secondary channels)", async () => {
 
-        QMConfig.secondarySlackChannels = [];
+        const command: OnboardMember = new OnboardMember();
+        command.teamId = "1234";
+        command.domainUsername = "domain/username";
+        command.email = "tester@gmail.com";
+        command.firstName = "Peter";
+        command.lastName = "BillyBob";
+        command.screenName = "p.b";
+        command.teamChannel = "something";
 
-        const axiosWrapper = new AwaitAxios();
-        const mock = new MockAdapter(axiosWrapper.axiosInstance);
+        const gluon = nock(QMConfig.subatomic.gluon.baseUrl)
+            .post("/members")
+            .reply(200, {});
 
-        mock.onPost(`${QMConfig.subatomic.gluon.baseUrl}/members`).reply(201, {
-            firstName: "Wang1",
-            lastName: "User",
-            email: "test.user@foo.co.za",
-            domainUsername: "tete528",
+        const context: TestQMContext = new TestQMContext();
 
-            slack: {
-                screenName: "Jason",
-                userId: "9USDA7D6dH",
-            },
-        });
+        await command.handleQMCommand(context);
 
-        const gluonService = new GluonService(axiosWrapper);
+        gluon.isDone();
 
-        const subject = new OnboardMember(gluonService);
-        subject.domainUsername = "tete528";
-        subject.email = "test.user@foo.co.za";
-        subject.firstName = "Wang1";
-        subject.userId = "9USDA7D6dH";
-        subject.lastName = "User";
-        subject.screenName = "Jason";
-
-        const fakeContext = {
-            teamId: "TEST",
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-            graphClient: new TestGraphClient(),
-        };
-
-        // fake results from inner methods
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "TCZLW7AT0"}]}});
-
-        fakeContext.graphClient.executeQueryResults.push({
-            result: true,
-            returnValue: {
-                ChatChannel: [{
-                    id: "AI6DFNN4K_CFN59SHPY",
-                    name: "subatomic-discussion",
-                    channelId: "CFN59SHPY",
-                }],
-            },
-        });
-
-        fakeContext.graphClient.executeQueryResults.push({
-            result: true,
-            returnValue: {inviteUserToSlackChannel: {id: "CFN59SHPY"}},
-        });
-
-        fakeContext.graphClient.executeQueryResults.push({
-            result: true,
-            returnValue: {
-                SlackDestination: {
-                    team: "TCZLW7AT0",
-                    userAgent: "slack",
-                    users: ["UE8SGB4QK"],
-                    channels: ["abc", "def"],
-                },
-            },
-        });
-
-        await subject.handle(fakeContext);
-        assert(fakeContext.messageClient.textMsg[0].text.trim() === "🚀 Welcome to the Subatomic environment *Wang1*!\n\n\n\nNext steps are to either join an existing team or create a new one.");
+        assert.equal(context.messageClient.responderMessageClient.messagesSent[0].text, "🚀 Welcome to the Subatomic environment *Peter*!\n\nYou have been added to the Subatomic community channel/s:\n *sub-discussion*\n\nNext steps are to either join an existing team or create a new one.");
     });
 });

--- a/test/gluon/commands/team/DevOpsEnvironmentTest.ts
+++ b/test/gluon/commands/team/DevOpsEnvironmentTest.ts
@@ -1,95 +1,60 @@
 import "mocha";
-import * as assert from "power-assert";
+import assert = require("power-assert");
 import {QMConfig} from "../../../../src/config/QMConfig";
 import {NewDevOpsEnvironment} from "../../../../src/gluon/commands/team/DevOpsEnvironment";
-import {GluonService} from "../../../../src/gluon/services/gluon/GluonService";
-import {AwaitAxios} from "../../../../src/http/AwaitAxios";
-import {TestGraphClient} from "../../TestGraphClient";
-import {TestMessageClient} from "../../TestMessageClient";
+import {TestQMContext} from "../../TestQMContext";
 
-const MockAdapter = require("axios-mock-adapter");
+const nock = require("nock");
 
-describe("Create a new or use an existing Openshift DevOps environment", () => {
-    it("Should use existing DevOps environment", async () => {
-        const axiosWrapper = new AwaitAxios();
-        const mock = new MockAdapter(axiosWrapper.axiosInstance);
+describe("NewDevOpsEnvironment command", () => {
+    it("should request a DevOps environment", async () => {
+
         const teamName = "test_name";
         const screenName = "Test.User";
         const teamChannel = "test_channel";
         const teamId = "79c41ee3-f092-4664-916f-da780195a51e";
         const memberId = "3d01d401-abb3-4eee-8884-2ed5a472172d";
 
-        mock.onGet(`${QMConfig.subatomic.gluon.baseUrl}/teams?name=${teamName}`).reply(200, {
-            _embedded: {
-                teamResources: [
-                    {
-                        memberId: `${memberId}`,
-                        teamId: `${teamId}`,
-                        slack: {
-                            screenName: `${screenName}`,
-                            userId: "9USDA7D6dH",
+        const gluon = nock(QMConfig.subatomic.gluon.baseUrl)
+            .get(`/teams?name=${teamName}`)
+            .reply(200, {
+                _embedded: {
+                    teamResources: [
+                        {
+                            teamId: `${teamId}`,
                         },
-                    },
-                ],
-            },
-        });
-
-        mock.onGet(`${QMConfig.subatomic.gluon.baseUrl}/teams?slackTeamChannel=${teamChannel}`).reply(200, {
-            _embedded: {
-                teamResources: [
-                    {
-                        name: `${teamName}`,
-                        memberId: `${memberId}`,
-                        teamId: `${teamId}`,
-                        slack: {
-                            screenName: `${screenName}`,
-                            userId: "9USDA7D6dH",
-                            teamChannel: `${teamChannel}`,
+                    ],
+                },
+            })
+            .get(`/members?slackScreenName=${screenName}`)
+            .reply(200, {
+                _embedded: {
+                    teamMemberResources: [
+                        {
+                            memberId: `${memberId}`,
                         },
+                    ],
+                },
+            })
+            .put(`/teams/${teamId}`,
+                {
+                    devOpsEnvironment: {
+                        requestedBy: memberId,
                     },
-                ],
-            },
-        });
+                }).reply(200);
 
-        mock.onGet(`${QMConfig.subatomic.gluon.baseUrl}/members?slackScreenName=${screenName}`).reply(200, {
-            _embedded: {
-                teamMemberResources: [
-                    {
-                        memberId: `${memberId}`,
-                        teamId: `${teamId}`,
-                        slack: {
-                            screenName: `${screenName}`,
-                            userId: "9USDA7D6dH",
-                        },
-                    },
-                ],
-            },
-        });
+        const command: NewDevOpsEnvironment = new NewDevOpsEnvironment();
 
-        mock.onPut(`${QMConfig.subatomic.gluon.baseUrl}/teams/${teamId}`).reply(200, {
-            devOpsEnvironment: {
-                requestedBy: `${memberId}`,
-            },
-        });
+        command.teamName = teamName;
+        command.teamChannel = teamChannel;
+        command.screenName = screenName;
 
-        const gluonService = new GluonService(axiosWrapper);
+        const context = new TestQMContext();
 
-        const subject = new NewDevOpsEnvironment(gluonService);
-        subject.teamName = `${teamName}`;
-        subject.teamChannel = `${teamChannel}`;
-        subject.screenName = `${screenName}`;
+        await command.runQMCommand(context);
 
-        const fakeContext = {
-            teamId: `${teamId}`,
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-            graphClient: new TestGraphClient(),
-        };
+        gluon.isDone();
 
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "1234"}]}});
-
-        await subject.handle(fakeContext);
-        assert(fakeContext.messageClient.textMsg[1] === `Requesting DevOps environment for *${teamName}* team.`);
+        assert.equal(context.messageClient.channelMessagesSent[0].message.text, `Requesting DevOps environment for *${teamName}* team.`);
     });
 });

--- a/test/gluon/events/team/DevOpsEnvironmentRequestedTest.ts
+++ b/test/gluon/events/team/DevOpsEnvironmentRequestedTest.ts
@@ -1,0 +1,107 @@
+import {ClientLogging, configureLogging} from "@atomist/automation-client";
+import "mocha";
+import assert = require("power-assert");
+import {QMConfig} from "../../../../src/config/QMConfig";
+import {DevOpsEnvironmentRequested} from "../../../../src/gluon/events/team/DevOpsEnvironmentRequested";
+import {TestQMContext} from "../../TestQMContext";
+
+const nock = require("nock");
+
+describe("DevOpsRequested event", () => {
+    it("should create a devops environment and provision a jenkins", async () => {
+        configureLogging(ClientLogging);
+        const devOpsEnvironmentRequestedEvent = {
+            id: 1,
+            team: {
+                teamId: "1",
+                name: "testing",
+                slackIdentity: {
+                    teamChannel: "tc",
+                },
+                openShiftCloud: "ab-cloud",
+                owners: [{
+                    firstName: "Rob",
+                    domainUsername: "domain/rob",
+                    slackIdentity: {
+                        screenName: "rob",
+                    },
+                }],
+                members: [],
+            },
+            requestedBy: {
+                firstName: "Rob",
+                slackIdentity: {
+                    screenName: "rob",
+                },
+            },
+        };
+
+        const jenkinsUrl = "https://www.jenkins-test.com";
+
+        const openshift = nock(QMConfig.subatomic.openshiftClouds["ab-cloud"].openshiftNonProd.masterUrl)
+            .log(console.log)
+            .post("/oapi/v1/projectrequests").reply(200) // Create project
+            .get("/api/v1/namespaces/testing-devops/resourcequotas/default-quota").reply(404) // Create default quotas
+            .post("/api/v1/namespaces/testing-devops/resourcequotas").reply(200)
+            .get("/api/v1/namespaces/testing-devops/limitranges/default-limits").reply(404) // Create default limits
+            .post("/api/v1/namespaces/testing-devops/limitranges").reply(200)
+            .get("/oapi/v1/namespaces/testing-devops/rolebindings").reply(200, {items: []}) // Add user permissions to devops
+            .post("/oapi/v1/namespaces/testing-devops/rolebindings").reply(200)
+            .get("/oapi/v1/namespaces/subatomic/rolebindings").reply(200, {items: []}) // Add user permissions to shared resources space
+            .post("/oapi/v1/namespaces/subatomic/rolebindings").reply(200)
+            .get("/api/v1/namespaces/testing-devops/secrets/bitbucket-ssh").reply(200) // Avoid trying to mock secret creation
+            .get("/oapi/v1/namespaces/subatomic/templates/jenkins-persistent-subatomic").reply(200, {parameters: []}) // Process and deploy the jenkins template
+            .post("/oapi/v1/namespaces/subatomic/processedtemplates").reply(200, {objects: []})
+            .get("/oapi/v1/namespaces/subatomic/rolebindings").reply(200, {items: []}) // Give jenkins sa permissions in shared resource space
+            .post("/oapi/v1/namespaces/subatomic/rolebindings").reply(200)
+            .get("/api/v1/namespaces/testing-devops/serviceaccounts/subatomic-jenkins").reply(400) // Give jenkins sa permissions in devops
+            .post("/api/v1/namespaces/testing-devops/serviceaccounts").reply(200)
+            .get("/oapi/v1/namespaces/testing-devops/rolebindings/subatomic-jenkins-edit").reply(400)
+            .post("/oapi/v1/namespaces/testing-devops/rolebindings").reply(200)
+            .get("/oapi/v1/namespaces/testing-devops/deploymentconfigs/jenkins/status").reply(200, { // Rollout Jenkins
+                spec: {replicas: 1},
+                status: {availableReplicas: 1},
+            })
+            .get("/oapi/v1/namespaces/testing-devops/routes/jenkins").reply(200, { // Get jenkins host
+                kind: "Route",
+                metadata: {name: "jenkins", annotations: []},
+                spec: {host: jenkinsUrl},
+            })
+            .patch("/oapi/v1/namespaces/testing-devops/routes/jenkins").reply(200) // Add annotations to jenkins host
+            .get("/oapi/v1/namespaces/testing-devops/routes/jenkins").reply(200, { // Get jenkins host
+                kind: "Route",
+                metadata: {name: "jenkins", annotations: []},
+                spec: {host: "www.jenkins-test.com"},
+            })
+            .get("/api/v1/namespaces/testing-devops/serviceaccounts/subatomic-jenkins").reply(200, { // Get the service account token to access jenkins
+                secrets: [{name: "subatomic-jenkins-token"}],
+            })
+            .get("/api/v1/namespaces/testing-devops/secrets/subatomic-jenkins-token").reply(200, {
+                data: {token: "MTIz"},
+            }).get("/oapi/v1/namespaces/testing-devops/routes/jenkins").reply(200, { // Get jenkins host
+                kind: "Route",
+                metadata: {name: "jenkins", annotations: []},
+                spec: {host: "www.jenkins-test.com"},
+            });
+
+        const jenkins = nock(jenkinsUrl)
+            .log(console.log)
+            .post("/credentials/store/system/domain/_/createCredentials").reply(200) // Mock all credential creations
+            .post("/credentials/store/system/domain/_/createCredentials").reply(200)
+            .post("/credentials/store/system/domain/_/createCredentials").reply(200)
+            .post("/credentials/store/system/domain/_/createCredentials").reply(200)
+            .post("/credentials/store/system/domain/_/createCredentials").reply(200);
+
+        const event: DevOpsEnvironmentRequested = new DevOpsEnvironmentRequested();
+
+        const context = new TestQMContext();
+
+        await event.handleQMEvent(devOpsEnvironmentRequestedEvent, context);
+
+        openshift.isDone();
+        jenkins.isDone();
+
+        assert.equal(context.messageClient.channelMessagesSent.pop().message.text, "Your Jenkins instance has been successfully provisioned in the DevOps environment: <https://www.jenkins-test.com>");
+        assert.equal(context.eventsRaised[0].eventName, "DevOpsEnvironmentProvisionedEvent");
+    });
+});

--- a/test/gluon/events/team/DevOpsEnvironmentRequestedTest.ts
+++ b/test/gluon/events/team/DevOpsEnvironmentRequestedTest.ts
@@ -1,4 +1,3 @@
-import {ClientLogging, configureLogging} from "@atomist/automation-client";
 import "mocha";
 import assert = require("power-assert");
 import {QMConfig} from "../../../../src/config/QMConfig";
@@ -9,7 +8,8 @@ const nock = require("nock");
 
 describe("DevOpsRequested event", () => {
     it("should create a devops environment and provision a jenkins", async () => {
-        configureLogging(ClientLogging);
+        // Use this if debugging is necessary
+        // configureLogging(ClientLogging);
         const devOpsEnvironmentRequestedEvent = {
             id: 1,
             team: {

--- a/test/gluon/services/member/OnboardMemberServiceTest.ts
+++ b/test/gluon/services/member/OnboardMemberServiceTest.ts
@@ -1,8 +1,6 @@
-import {url} from "@atomist/slack-messages";
 import assert = require("power-assert");
 import {OnboardMemberService} from "../../../../src/gluon/services/member/OnboardMemberService";
-import {TestGraphClient} from "../../TestGraphClient";
-import {TestMessageClient} from "../../TestMessageClient";
+import {TestQMContext} from "../../TestQMContext";
 
 describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
 
@@ -10,67 +8,41 @@ describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
 
         const service = new OnboardMemberService();
 
-        const fakeContext = {
-            teamId: "TEST",
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-            graphClient: new TestGraphClient(),
-        };
-
-        // Force invite to fail
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "1234"}]}});
-        fakeContext.graphClient.executeMutationResults.push({
-            result: false,
-            returnValue: {networkError: {statusCode: 400}},
+        const context: TestQMContext = new TestQMContext();
+        context.graphClient.inviteUserToChannelResponse.push({
+            success: false,
+            body: {
+                networkError: {
+                    statusCode: 400,
+                },
+            },
         });
 
-        await service.inviteUserToSecondarySlackChannel(fakeContext,
+        await service.inviteUserToSecondarySlackChannel(context,
+            "1234",
             "Jude",
             "channel1",
             "channe1id",
             "Howard",
         );
 
-        assert.equal(fakeContext.messageClient.textMsg[0], "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
+        assert.equal(context.messageClient.channelMessageClient.messagesSent[0].text, "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
     });
 
     it("should invite user to custom slack channel and return channel name", async () => {
 
         const service = new OnboardMemberService();
 
-        const fakeContext = {
-            teamId: "TEST",
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-            graphClient: new TestGraphClient(),
-        };
+        const context: TestQMContext = new TestQMContext();
 
-        // fake results from inner methods
-        fakeContext.graphClient.executeQueryResults.push({result: true, returnValue: {ChatTeam: [{id: "TCZLW7AT0"}]}});
-        fakeContext.graphClient.executeQueryResults.push({
-            result: true,
-            returnValue: {
-                ChatChannel: [{
-                    id: "AI6DFNN4K_CFN59SHPY",
-                    name: "subatomic-discussion",
-                    channelId: "CFN59SHPY",
-                }],
-            },
-        });
-        fakeContext.graphClient.executeMutationResults.push({
-            result: true,
-            returnValue: {inviteUserToSlackChannel: {id: "CFN59SHPY"}},
-        });
-
-        const res = await service.inviteUserToSecondarySlackChannel(fakeContext,
+        const res = await service.inviteUserToSecondarySlackChannel(context,
+            "12345",
             "Jude",
             "channel1",
             "channe1id",
             "Howard",
         );
 
-        assert.equal(res, `channel1`);
+        assert.equal(res, "channel1");
     });
 });

--- a/test/gluon/services/member/OnboardMemberServiceTest.ts
+++ b/test/gluon/services/member/OnboardMemberServiceTest.ts
@@ -26,7 +26,7 @@ describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
             "Howard",
         );
 
-        assert.equal(context.messageClient.channelMessagesSent[0].text, "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
+        assert.equal(context.messageClient.channelMessagesSent[0].message.text, "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
     });
 
     it("should invite user to custom slack channel and return channel name", async () => {

--- a/test/gluon/services/member/OnboardMemberServiceTest.ts
+++ b/test/gluon/services/member/OnboardMemberServiceTest.ts
@@ -26,7 +26,7 @@ describe("AddMemberToTeamService inviteUserToCustomSlackChannel", () => {
             "Howard",
         );
 
-        assert.equal(context.messageClient.channelMessageClient.messagesSent[0].text, "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
+        assert.equal(context.messageClient.channelMessagesSent[0].text, "Invitation to channel *channel1* failed for *Howard*.\n Note, private channels do not currently support automatic user invitation.\nPlease invite the user to this slack channel manually.");
     });
 
     it("should invite user to custom slack channel and return channel name", async () => {

--- a/test/gluon/services/team/AddMemberToTeamServiceTest.ts
+++ b/test/gluon/services/team/AddMemberToTeamServiceTest.ts
@@ -10,6 +10,7 @@ import {MemberRole} from "../../../../src/gluon/util/member/Members";
 import {QMError} from "../../../../src/gluon/util/shared/Error";
 import {TestGraphClient} from "../../TestGraphClient";
 import {TestMessageClient} from "../../TestMessageClient";
+import {TestQMContext} from "../../TestQMContext";
 
 describe("AddMemberToTeamService getNewMemberGluonDetails", () => {
     it("should return member details", async () => {
@@ -29,14 +30,10 @@ describe("AddMemberToTeamService getNewMemberGluonDetails", () => {
         }));
         const gluonService = new GluonService(undefined, undefined, instance(mockedMemberService));
         const service = new AddMemberToTeamService(gluonService);
-        const fakeContext = {
-            teamId: "TEST",
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-        };
 
-        const result = await service.getNewMemberGluonDetails(fakeContext, "Dex", "Channel2");
+        const context = new TestQMContext();
+
+        const result = await service.getNewMemberGluonDetails(context, "Dex", "Channel2");
 
         assert.equal(result.id, "User1");
 

--- a/test/gluon/services/team/RemoveMemberFromTeamService.ts
+++ b/test/gluon/services/team/RemoveMemberFromTeamService.ts
@@ -7,7 +7,6 @@ import {MemberService} from "../../../../src/gluon/services/gluon/MemberService"
 import {TeamService} from "../../../../src/gluon/services/gluon/TeamService";
 import {RemoveMemberFromTeamService} from "../../../../src/gluon/services/team/RemoveMemberFromTeamService";
 import {QMError} from "../../../../src/gluon/util/shared/Error";
-import {TestMessageClient} from "../../TestMessageClient";
 
 describe("RemoveMemberFromTeamService getMemberGluonDetails", () => {
     it("should return existing member details", async () => {
@@ -27,14 +26,8 @@ describe("RemoveMemberFromTeamService getMemberGluonDetails", () => {
         }));
         const gluonService = new GluonService(undefined, undefined, instance(mockedMemberService));
         const service = new RemoveMemberFromTeamService(gluonService);
-        const fakeContext = {
-            teamId: "TEST",
-            correlationId: "1231343234234",
-            workspaceId: "2341234123",
-            messageClient: new TestMessageClient(),
-        };
 
-        const result = await service.getMemberGluonDetails(fakeContext, "Dex");
+        const result = await service.getMemberGluonDetails("Dex");
 
         assert.equal(result.id, "User1");
 


### PR DESCRIPTION
### Description
This PR looks at refactoring how we interact with Atomist HandlerContext with the aim of improving what we are capable of testing. The main goal here is to put an abstraction in front of the HandlerContext such that it is simpler for us to fake and track the interactions our code has with the context. It also possibly creates a way for us to support alternate run contexts besides using Atomist alone.

Along with the change to the context we use this change also incorporates the use of [Nock](https://www.npmjs.com/package/nock#logging) for our integration point mocking. 

The combination of these two changes allows to write tests which test the full run through of a command or event from start to end. This gives us a better way to test based on features vs functional unit testing we have tried in the past (this is also really hard because we are not in control of how commands and events are invoked preventing use of something like DI).

**This is a POC put up for review on the principles it implements. This needs further testing and discussion before we merge this change**

### Essential Checks:

* [X] Have you added tests where necessary?
* [X] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [X] Have you added new commands to the displayable Help list?
* [X] Have you updated any necessary documentation?
