### PR TITLE
Get Bitbucket project key from application for adding jenkinsfiles

### DIFF
--- a/src/gluon/tasks/packages/ConfigurePackageDeploymentPipelineInJenkins.ts
+++ b/src/gluon/tasks/packages/ConfigurePackageDeploymentPipelineInJenkins.ts
@@ -23,6 +23,7 @@ import {
     JenkinsDeploymentJobTemplate,
     JenkinsJobTemplate,
 } from "../../util/jenkins/JenkinsJobTemplates";
+import {bitbucketProjectKeyFromRepositoryRemoteUrl} from "../../util/packages/Applications";
 import {QMProject} from "../../util/project/Project";
 import {getDevOpsEnvironmentDetails, QMTeam} from "../../util/team/Teams";
 import {Task} from "../Task";
@@ -60,7 +61,7 @@ export class ConfigurePackageDeploymentPipelineInJenkins extends Task {
             owningTeam.name,
             this.application,
             this.jenkinsDeploymentJobConfigs,
-            this.project.bitbucketProject.key,
+            bitbucketProjectKeyFromRepositoryRemoteUrl(this.application.bitbucketRepository.remoteUrl),
             this.application.bitbucketRepository.slug,
         );
         await this.taskListMessage.succeedTask(this.TASK_ADD_JENKINS_FILE);

--- a/src/gluon/tasks/packages/ConfigurePackagePipelineInJenkins.ts
+++ b/src/gluon/tasks/packages/ConfigurePackagePipelineInJenkins.ts
@@ -17,6 +17,7 @@ import {
     getSubatomicJenkinsServiceAccountName,
 } from "../../util/jenkins/Jenkins";
 import {JenkinsJobTemplate} from "../../util/jenkins/JenkinsJobTemplates";
+import {bitbucketProjectKeyFromRepositoryRemoteUrl} from "../../util/packages/Applications";
 import {QMProject} from "../../util/project/Project";
 import {getDevOpsEnvironmentDetails, QMTeam} from "../../util/team/Teams";
 import {Task} from "../Task";
@@ -53,7 +54,7 @@ export class ConfigurePackagePipelineInJenkins extends Task {
         if (!_.isEmpty(this.jenkinsJobTemplate.sourceJenkinsfile)) {
             await this.addJenkinsFile(
                 this.jenkinsJobTemplate.sourceJenkinsfile,
-                this.project.bitbucketProject.key,
+                bitbucketProjectKeyFromRepositoryRemoteUrl(this.application.bitbucketRepository.remoteUrl),
                 this.application.bitbucketRepository.slug,
                 this.jenkinsJobTemplate.expectedJenkinsfile,
             );

--- a/src/gluon/util/packages/Applications.ts
+++ b/src/gluon/util/packages/Applications.ts
@@ -33,3 +33,8 @@ export function menuAttachmentForApplications(ctx: HandlerContext, applications:
 export function getBuildConfigName(projectName: string, packageName: string): string {
     return `${_.kebabCase(projectName).toLowerCase()}-${_.kebabCase(packageName).toLowerCase()}`;
 }
+
+export function bitbucketProjectKeyFromRepositoryRemoteUrl(remoteUrl: string) {
+    const remoteSplit = remoteUrl.split("/");
+    return remoteSplit[remoteSplit.length - 2];
+}


### PR DESCRIPTION
### Description
Added functions to pull the bitbucket project key from the application bitbucket remote url instead of using the project bitbucket key. This is a temporary patch for us to segue to allowing multiple bitbucket projects associated to a subatomic account.

### Essential Checks:

* [X] Have you added tests where necessary?
* [X] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [X] Have you added new commands to the displayable Help list?
* [X] Have you updated any necessary documentation?
