### PR TITLE
Output jenkins url at build time #965

### DIFF
--- a/src/gluon/commands/jenkins/JenkinsBuild.ts
+++ b/src/gluon/commands/jenkins/JenkinsBuild.ts
@@ -94,7 +94,6 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand
 
         logger.debug(`Using Jenkins Route host [${jenkinsHost}] to kick off build`);
 
-
         const kickOffBuildResult = await this.jenkinsService.kickOffBuild(
             jenkinsHost,
             token,

--- a/src/gluon/commands/jenkins/JenkinsBuild.ts
+++ b/src/gluon/commands/jenkins/JenkinsBuild.ts
@@ -7,6 +7,7 @@ import {
     Tags,
 } from "@atomist/automation-client";
 import {CommandHandler} from "@atomist/automation-client/lib/decorators";
+import {url} from "@atomist/slack-messages";
 import {QMConfig} from "../../../config/QMConfig";
 import {ResponderMessageClient} from "../../../context/QMMessageClient";
 import {isSuccessCode} from "../../../http/Http";
@@ -93,6 +94,7 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand
 
         logger.debug(`Using Jenkins Route host [${jenkinsHost}] to kick off build`);
 
+
         const kickOffBuildResult = await this.jenkinsService.kickOffBuild(
             jenkinsHost,
             token,
@@ -101,7 +103,7 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand
         );
         if (isSuccessCode(kickOffBuildResult.status)) {
             return await ctx.messageClient.respond({
-                text: `🚀 *${gluonApplicationName}* is being built...`,
+                text: `🚀 *${gluonApplicationName}* is being built at ${url(`https://${jenkinsHost}`)} ...`,
             });
         } else {
             if (kickOffBuildResult.status === 404) {
@@ -113,7 +115,7 @@ export class KickOffJenkinsBuild extends RecursiveParameterRequestCommand
                     gluonApplicationName,
                 );
                 return await ctx.messageClient.respond({
-                    text: `🚀 *${gluonApplicationName}* is being built for the first time...`,
+                    text: `🚀 *${gluonApplicationName}* is being built for the first time at ${url(`https://${jenkinsHost}`)} ...`,
                 });
             } else {
                 logger.error(`Failed to kick off JenkinsBuild. Error: ${JSON.stringify(kickOffBuildResult)}`);


### PR DESCRIPTION
### Description
Output jenkins url when clicking Start Build after configuring package:

![image](https://user-images.githubusercontent.com/36840575/61123553-eaa84980-a4a4-11e9-8eb6-b178548bb2b6.png)

![image](https://user-images.githubusercontent.com/36840575/61123540-debc8780-a4a4-11e9-8ef2-f79ca23ff62e.png)


### Essential Checks:

* [x] Have you added tests where necessary?
* [x] Have you added metric gathering code where necessary (in `EventHandlers` and `CommandHandlers`)?
* [x] Have you added new commands to the displayable Help list?
* [x] Have you updated any necessary documentation?
